### PR TITLE
Jellyman v1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 ======
 
-> v1.5.2 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.5.3 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34/35/36, Ubuntu 22.04, Manjaro 21.3.6, and Linux Mint 21
 

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.5.2
+.B Jellyman - The Jellyfin Manager - v1.5.3
 
 .SH SYNOPSIS
 .B jellyman

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -82,12 +82,12 @@ Download_version()
    source /opt/jellyfin/config/jellyman.conf
    mkdir /opt/jellyfin/update
    wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/
-   cat /opt/jellyfin/update/index.html | grep "-" | sed -e 's/<a href="//g' | sed -e "s|/.*||g" | cat -n
+   cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n
    echo
    echo "Please enter the number corresponding with"
    read -p "the version you want to install : " versionToSwitchNumber
-   newVersion=$(cat /opt/jellyfin/update/index.html | grep "-" | sed -e 's/<a href="//g' | sed -e "s|/.*||g" | head -n $versionToSwitchNumber | tail -n 1)
-   maxNumber=$(cat /opt/jellyfin/update/index.html | grep "-" | sed -e 's/<a href="//g' | sed -e "s|/.*||g" | wc -l)
+   newVersion=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | head -n $versionToSwitchNumber | tail -n 1)
+   maxNumber=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | wc -l)
     if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
       echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
      exit
@@ -713,7 +713,8 @@ if [ -n "$1" ]; then
                 Update $2
                 shift
              fi ;;
-         -U) Update-jellyman ;;
+         -U) Update-jellyman 
+             exit ;;
          -ub) Update_beta ;;
          -v) Get_version ;;
          -vd) Download_version ;;

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -147,7 +147,7 @@ Remove_version()
 Help()
 {
    # Display Help
-   echo "Jellyman - The Jellyfin Manager v1.5.2"
+   echo "Jellyman - The Jellyfin Manager v1.5.3"
    echo "-Created by Smiley McSmiles"
    echo 
    echo "Syntax: jellyman -[COMMAND] [PARAMETER]"

--- a/setup.sh
+++ b/setup.sh
@@ -166,13 +166,14 @@ Setup()
    cp scripts/jellyfin.sh /opt/jellyfin/
    touch /opt/jellyfin/config/jellyman.conf
    mv $jellyfin_archive /opt/jellyfin/
+   jellyfinServiceLocation=
    
    if [ -d /usr/lib/systemd/system ]; then
       cp conf/jellyfin.service /usr/lib/systemd/system/
-      echo "jellyfinServiceLocation=/usr/lib/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf
+      jellyfinServiceLocation="/usr/lib/systemd/system/jellyfin.service"
    else
       cp conf/jellyfin.service /etc/systemd/system/
-      echo "jellyfinServiceLocation=/etc/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf
+      jellyfinServiceLocation="/etc/systemd/system/jellyfin.service"
    fi
    
    cp conf/jellyfin.conf /etc/
@@ -188,6 +189,7 @@ Setup()
    echo "httpsPort=8920" >> config/jellyman.conf
    echo "currentVersion=$jellyfin" >> config/jellyman.conf
    echo "defaultUser=$defaultUser" >> config/jellyman.conf
+   echo "jellyfinServiceLocation=$jellyfinServiceLocation" >> config/jellyman.conf
 
    Install_dependancies
 
@@ -282,9 +284,9 @@ Update_jellyman()
    fi
    
    if [ -d /usr/lib/systemd ] && [[ ! -n $jellyfinServiceLocation ]]; then
-      echo "jellyfinServiceLocation=/usr/lib/systemd/system/" >> /opt/jellyfin/config/jellyman.conf
-   elif [ ! -n $jellyfinServiceLocation ]; then
-      echo "jellyfinServiceLocation=/etc/systemd/system/" >> /opt/jellyfin/config/jellyman.conf
+      bash -c 'echo "jellyfinServiceLocation=/usr/lib/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf'
+   elif [[ ! -n $jellyfinServiceLocation ]]; then
+      bash -c 'echo "jellyfinServiceLocation=/etc/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf'
    fi
 
    echo "...complete"

--- a/setup.sh
+++ b/setup.sh
@@ -167,12 +167,12 @@ Setup()
    touch /opt/jellyfin/config/jellyman.conf
    mv $jellyfin_archive /opt/jellyfin/
    
-   if [ -d /usr/lib/systemd ]; then
+   if [ -d /usr/lib/systemd/system ]; then
       cp conf/jellyfin.service /usr/lib/systemd/system/
-      echo "jellyfinServiceLocation=/usr/lib/systemd/system/" >> /opt/jellyfin/config/jellyman.conf
+      echo "jellyfinServiceLocation=/usr/lib/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf
    else
       cp conf/jellyfin.service /etc/systemd/system/
-      echo "jellyfinServiceLocation=/etc/systemd/system/" >> /opt/jellyfin/config/jellyman.conf
+      echo "jellyfinServiceLocation=/etc/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf
    fi
    
    cp conf/jellyfin.conf /etc/
@@ -281,7 +281,7 @@ Update_jellyman()
       echo "httpsPort=8920" >> /opt/jellyfin/config/jellyman.conf
    fi
    
-   if [ -d /usr/lib/systemd ] && [ ! -n $jellyfinServiceLocation ]; then
+   if [ -d /usr/lib/systemd ] && [[ ! -n $jellyfinServiceLocation ]]; then
       echo "jellyfinServiceLocation=/usr/lib/systemd/system/" >> /opt/jellyfin/config/jellyman.conf
    elif [ ! -n $jellyfinServiceLocation ]; then
       echo "jellyfinServiceLocation=/etc/systemd/system/" >> /opt/jellyfin/config/jellyman.conf


### PR DESCRIPTION

## Fixes
-Fixed setup.sh not updating where jellyfin.service is located. This is useful for deletion of the jellyfin.service file.
-Fixed terminal grossness when updating Jellyman

## Changes
-Changed how Jellyman searches for new updates. More changes to come here.