### PR TITLE
Jellyfin v1.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 ======
 
-> v1.5.4 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.5.5 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34/35/36, Ubuntu 22.04, Manjaro 21.3.6, Linux Mint 21, and Rocky Linux 9.0
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > v1.5.5 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
-> Tested on Fedora 34/35/36, Ubuntu 22.04, Manjaro 21.3.6, Linux Mint 21, and Rocky Linux 9.0
+> Tested on Fedora 34/35/36, Ubuntu 22.04, Manjaro 21.3.6, EndeavourOS Artemis Neo, Linux Mint 21, and Rocky Linux 9.0
 
 > Should work on Any Debian, Arch, or RHEL Based Distribution
 

--- a/conf/jellyfin.service
+++ b/conf/jellyfin.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Jellyfin Server is a personal media server.
+Description=Jellyfin Media Server - Installed by Jellyman
 After=network.target
 
 [Service]

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.5.4
+.B Jellyman - The Jellyfin Manager - v1.5.5
 
 .SH SYNOPSIS
 .B jellyman

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+jellymanVersion="1.5.5"
+
 ###############################################################################
 # FUNCTIONS                                                                   #
 ###############################################################################
@@ -58,9 +60,14 @@ Check_disk_free()
 {
    source /opt/jellyfin/config/jellyman.conf
    if [[ $defaultPath != /* ]]; then 
-      echo "No default directory found..."
-      echo "Please enter the root directory for your Media Library..."
-      echo "DO NOT ENTER YOUR USER DIRECTORY AS IT WILL RESET PERMISSIONS OF THE ENTERED DIRECTORY TO YOUR JELLYFIN USER"
+      echo "|-----------------------------------------------|"
+      echo "|          No default directory found...        |"
+      echo "|     Please enter the root directory for       |"
+      echo "|              your Media Library               |"
+      echo "|    DO NOT ENTER YOUR USER DIRECTORY AS IT     |"
+      echo "|    WILL RESET PERMISSIONS OF THE ENTERED      |"
+      echo "|       DIRECTORY TO YOUR JELLYFIN USER         |"
+      echo "|-----------------------------------------------|"
       read defaultPath
       sed -i -e "s|defaultPath=.*|defaultPath=$defaultPath|g" /opt/jellyfin/config/jellyman.conf
       df -h $defaultPath
@@ -74,6 +81,7 @@ Get_version()
    Has_sudo
    source /opt/jellyfin/config/jellyman.conf
    echo "$currentVersion"
+   echo "Jellyman v$jellymanVersion"
 }
 
 Download_version()
@@ -147,7 +155,7 @@ Remove_version()
 Help()
 {
    # Display Help
-   echo "Jellyman - The Jellyfin Manager v1.5.5"
+   echo "Jellyman - The Jellyfin Manager v$jellymanVersion"
    echo "-Created by Smiley McSmiles"
    echo 
    echo "Syntax: jellyman -[COMMAND] [PARAMETER]"
@@ -180,7 +188,7 @@ Help()
    echo
    echo "To browse Jellyfin versions please use this link."
    echo "***WARNING*** ONLY USE COMBINED(Web & Server) PACKAGES"
-   echo https://repo.jellyfin.org/releases/server/linux/versions/
+   echo "https://repo.jellyfin.org/releases/server/linux/versions/"
 }
 
 Import()
@@ -300,7 +308,8 @@ Http_port_change()
       elif [ -x "$(command -v firewall-cmd)" ]; then 
          firewall-cmd --permanent --zone=public --add-port=$port/tcp
          firewall-cmd --reload
-      else echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
+      else
+         echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
       fi
    else
       exit
@@ -324,7 +333,8 @@ Https_port_change()
       elif [ -x "$(command -v firewall-cmd)" ]; then 
          firewall-cmd --permanent --zone=public --add-port=$port/tcp
          firewall-cmd --reload
-      else echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
+      else
+         echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
       fi
    else
       exit
@@ -554,20 +564,27 @@ Rename_tv()
    clear
    nameOfTestFile=$(ls -1 $directoryToCorrect | head -1)
    
-   name2=$(echo $nameOfTestFile | cut -d "/" -f 2)
-   name3=$(echo $nameOfTestFile | cut -d "/" -f 3)
-   name4=$(echo $nameOfTestFile | cut -d "/" -f 4)
-   name5=$(echo $nameOfTestFile | cut -d "/" -f 5)
-   name6=$(echo $nameOfTestFile | cut -d "/" -f 6)
-   echo "2:$name2"
-   echo "3:$name3"
-   echo "4:$name4"
-   echo "5:$name5"
-   echo "6:$name6"
-   echo
-   echo
+   testDirCount=$(echo $directoryToCorrect | grep -o "/" | wc -w)
+   echo $testDirCount
+
+   if [[ $directoryToCorrect != *"/" ]]; then
+      testDirCount=$(($testDirCount + 1))
+   fi
+
+   iteration=2
+   number=1
+
+   while [ $number -lt $testDirCount ]; do
+      testName=$(echo $directoryToCorrect | cut -d "/" -f $iteration)
+      echo "$number : $testName"
+      iteration=$(($iteration + 1))
+      
+      number=$(($number + 1))   
+   done
+   
    echo "Please enter the number that corresponds with the show's name above"
    read directoryNumber
+   directoryNumber=$(($directoryNumber + 1))
    nameOfShow=$(dirname "$directoryToCorrect" | cut -d "/" -f $directoryNumber)
    echo "You chose $nameOfShow"
 
@@ -643,11 +660,19 @@ Uninstall()
 Update-jellyman()
 {
    Has_sudo
-   echo "Updating Jellyman - The Jellyfin Manager"
-   git clone https://github.com/Smiley-McSmiles/jellyman
-   cd jellyman
-   chmod ug+x setup.sh
-   sudo ./setup.sh -U
+   wget -O /opt/jellyfin/config/jellyman_version https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1
+   currentJellymanVersion=$(cat /opt/jellyfin/config/jellyman_version | grep " - v" | cut -d "v" -f2)
+   rm -f /opt/jellyfin/config/jellyman_version
+   if [[ $currentJellymanVersion == $jellymanVersion ]]; then
+      echo "Jellyman is up to date. No new versions available."
+      exit
+   else
+      echo "Updating Jellyman - The Jellyfin Manager from $jellymanVersion to v$currentJellymanVersion"
+      git clone https://github.com/Smiley-McSmiles/jellyman
+      cd jellyman
+      chmod ug+x setup.sh
+      sudo ./setup.sh -U
+   fi
 }
 
 Change_Media_Directory()

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -147,7 +147,7 @@ Remove_version()
 Help()
 {
    # Display Help
-   echo "Jellyman - The Jellyfin Manager v1.5.4"
+   echo "Jellyman - The Jellyfin Manager v1.5.5"
    echo "-Created by Smiley McSmiles"
    echo 
    echo "Syntax: jellyman -[COMMAND] [PARAMETER]"

--- a/setup.sh
+++ b/setup.sh
@@ -282,11 +282,11 @@ Setup()
    jellyman -t
    echo
    read -p "Would you like to remove the git cloned directory $DIRECTORY? [Y/n] :" deleteOrNot
-   if [[ $deleteOrNot == [yY]* ]]; then
+   if [[ $deleteOrNot == [nN]* ]]; then
+      echo "Okay, keeping $DIRECTORY"
+   else
       echo "Removing git cloned directory:$DIRECTORY..."
       rm -rf $DIRECTORY
-   else
-      echo "Okay, keeping $DIRECTORY"
    fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -287,7 +287,7 @@ Setup()
    else
       echo "Okay, keeping $DIRECTORY"
    rm -rf $DIRECTORY
-
+   fi
 }
 
 Pre_setup()

--- a/setup.sh
+++ b/setup.sh
@@ -159,12 +159,20 @@ Setup()
 {
    echo "Fetching newest stable Jellyfin version..."
    Get_Architecture
-   wget https://repo.jellyfin.org/releases/server/linux/stable/combined/
-   jellyfin_archive=$(grep "$architecture.tar.gz" index.html | cut -d '"' -f 2 | sed -r "s|.sha256sum||g" | head -1)
-   rm index.html
-   wget https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
-   jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-
+   jellyfin=
+   jellyfin_archive=
+   
+   if [ ! -f *"tar.gz" ]; then
+      wget https://repo.jellyfin.org/releases/server/linux/stable/combined/
+      jellyfin_archive=$(grep "$architecture.tar.gz" index.html | cut -d '"' -f 2 | sed -r "s|.sha256sum||g" | head -1)
+      rm index.html
+      wget https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
+      jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
+   else
+      jellyfin_archive=$(ls *.tar.gz)
+      jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
+   fi
+   
    mkdir /opt/jellyfin
    clear
 
@@ -188,7 +196,7 @@ Setup()
    cp scripts/jellyman /bin/
    cp scripts/jellyfin.sh /opt/jellyfin/
    touch /opt/jellyfin/config/jellyman.conf
-   mv $jellyfin_archive /opt/jellyfin/
+   cp $jellyfin_archive /opt/jellyfin/
    jellyfinServiceLocation=
    
    if [ -d /usr/lib/systemd/system ]; then
@@ -239,8 +247,6 @@ Setup()
       echo "|-------------------------------------------------------------------|"
    fi
 
-   echo "Removing git cloned directory:$DIRECTORY..."
-   rm -rf $DIRECTORY
    echo
    echo
    echo "DONE"
@@ -274,6 +280,14 @@ Setup()
    echo
    read -p " Press ENTER to continue" ENTER
    jellyman -t
+   echo
+   read -p "Would you like to remove the git cloned directory $DIRECTORY? [Y/n] :" deleteOrNot
+   if [[ $deleteOrNot == [yY]* ]]; then
+      echo "Removing git cloned directory:$DIRECTORY..."
+   else
+      echo "Okay, keeping $DIRECTORY"
+   rm -rf $DIRECTORY
+
 }
 
 Pre_setup()

--- a/setup.sh
+++ b/setup.sh
@@ -284,9 +284,9 @@ Setup()
    read -p "Would you like to remove the git cloned directory $DIRECTORY? [Y/n] :" deleteOrNot
    if [[ $deleteOrNot == [yY]* ]]; then
       echo "Removing git cloned directory:$DIRECTORY..."
+      rm -rf $DIRECTORY
    else
       echo "Okay, keeping $DIRECTORY"
-   rm -rf $DIRECTORY
    fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -138,6 +138,7 @@ Install_dependancies()
             linuxmint)  apt install $packagesNeededDebian -y ;;
             elementary) apt install $packagesNeededDebian -y ;;
             arch)       pacman -Syu $packagesNeededArch  ;;
+            endeavouros) pacman -Syu $packagesNeededArch  ;;
             manjaro)    pacman -Syu $packagesNeededArch  ;;
             opensuse*)  zypper install $packagesNeededOpenSuse ;;
          esac


### PR DESCRIPTION
### Added
-Added ability in setup.sh to keep Jellyman's installer files.
-- This helps people test Jellyman on their systems without having to re-download
-- their version of Jellyfin every time.

### Fixed
-Fixed `jellyman -rn` only displaying 6 names when given a directory.

### Changed
-Changed pinted message for Jellymans check for media directory funcion for better readability
-`jellyman -U` now checks if there is an update available for Jellyman before downloading a new version.