### PR TITLE
Jellyman v1.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.6.3 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.6.4 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34/35/36, Ubuntu 22.04, Manjaro 21.3.6, EndeavourOS Artemis Neo, Linux Mint 21, and Rocky Linux 8.6/9.0
 

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.6.3
+.B Jellyman - The Jellyfin Manager - v1.6.4
 
 .SH SYNOPSIS
 .B jellyman

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -129,13 +129,14 @@ Download_version()
 	Has_sudo
 	source /opt/jellyfin/config/jellyman.conf
 	mkdir /opt/jellyfin/update
-	wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/
-	cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n
+	versionList=$(curl -sL https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/)
+	clear
+	echo $versionList | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n
 	echo
 	echo "Please enter the number corresponding with"
 	read -p "the version you want to install : " versionToSwitchNumber
-	newVersion=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | head -n $versionToSwitchNumber | tail -n 1)
-	maxNumber=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | wc -l)
+	newVersion=$(echo $versionList | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | head -n $versionToSwitchNumber | tail -n 1)
+	maxNumber=$(echo $versionList | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | wc -l)
 	 if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
 		echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
 	  exit
@@ -144,7 +145,6 @@ Download_version()
 		echo "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
 		jellyman -u "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
 	fi
-	rm -fv /opt/jellyfin/update/index.html
 }
 
 Version_switch()
@@ -470,10 +470,9 @@ Update()
 	else
 		echo "Getting current version from repository..."
 		mkdir /opt/jellyfin/update
-		wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/stable/combined/
-		jellyfin_archive=$(grep "$architecture.tar.gz" /opt/jellyfin/update/index.html | cut -d '"' -f 2 | head -1 | sed -r "s|.sha256sum||g" | sed -r "s|-musl||g")
+		stableReleases=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable/combined/)
+		jellyfin_archive=$(echo $stableReleases | grep -o "jellyfin_"[0-9][0-9].[0-9].[0-9]"_$architecture.tar.gz" | head -1)
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-		rm -f /opt/jellyfin/update/index.html
 		
 		echo "jellyfin_archive = $jellyfin_archive"
 		echo "jellyfin = $jellyfin"
@@ -511,16 +510,14 @@ Update_beta()
 	
 	echo "Fetching newest beta Jellyfin version..."
 	mkdir /opt/jellyfin/update
-	wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/stable-pre/
-	jellyfin_archive=$(grep "$architecture.tar.gz" /opt/jellyfin/update/index.html | grep 'combined' | cut -d '/' -f5 | cut -d '<' -f1 | head -n 1 | sed -r "s|.sha256sum||g")
+	betasAvailable=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable-pre/) # needs testing when new beta is available
+	jellyfin_archive=$(echo $betasAvailable | grep "$architecture.tar.gz" | grep 'combined' | cut -d '/' -f5 | cut -d '<' -f1 | head -n 1 | sed -r "s|.sha256sum||g")
 	jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
 	new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
 	if [[ ! -n $jellyfin_archive ]] || [[ ! -n $jellyfin ]]; then
 		echo "Sorry there appears to be no Jellyfin Betas right now..."
 		exit
 	else
-		rm -f /opt/jellyfin/update/index.html
-
 		if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
 			wget -O /opt/jellyfin/update/$jellyfin_archive https://repo.jellyfin.org/releases/server/linux/stable-pre/$new_jellyfin_version/combined/$jellyfin_archive
 		else
@@ -859,9 +856,8 @@ Countdown()
 Update-jellyman()
 {
 	Has_sudo
-	wget -O /opt/jellyfin/config/jellyman_version https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1
-	currentJellymanVersion=$(cat /opt/jellyfin/config/jellyman_version | grep " - v" | cut -d "v" -f2)
-	rm -f /opt/jellyfin/config/jellyman_version
+	jellymanManFile=$(curl -sL https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1)
+	currentJellymanVersion=$(echo $jellymanManFile | grep " - v" | cut -d "v" -f2 | cut -d " " -f1)
 	if [[ "v$currentJellymanVersion" == $jellymanVersion ]]; then
 		echo "Jellyman is up to date. No new versions available."
 		exit

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -28,9 +28,6 @@ Backup()
 	USER=$(stat -c '%U' $backupDirectory)
 	chown -f $USER:$USER $tarPath
 	chmod -f 660 $tarPath
-	echo "Your backup is:"
-	tarSize=$(du -h $tarPath)
-	echo "Size: $tarSize"
 	echo
 	echo "|--------------------------------------------------------|"
 	echo "|        To Import on your next setup, simply run:       |"
@@ -39,6 +36,10 @@ Backup()
 	echo "|                   chmod ug+x setup.sh                  |"
 	echo "|     sudo ./setup.sh -i [Path to jellyfin-backup.tar]   |"
 	echo "|--------------------------------------------------------|"
+	echo
+	echo "Your backup is:"
+	tarSize=$(du -h $tarPath)
+	echo "Size: $tarSize"
 }
 
 Change_variable()
@@ -146,10 +147,12 @@ Download_version()
 
 		if [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; then
 			versionToSwitchnumber=0
-			warning="Please select one of the numbers provided!"
+			warning="ERROR: Please select one of the numbers provided!"
+			echo "Press CTRL+C to exit..."
 		elif isCurrentVersion jellyfin_$newVersionNumber || isInstalledVersion jellyfin_$newVersionNumber; then
 			versionToSwitchnumber=0
-			warning="That Jellyfin version is already installed!"
+			warning="ERROR: That Jellyfin version is already installed!"
+			echo "Press CTRL+C to exit..."
 		else
 			newVersionUnderscore=$(echo "$newVersionNumber"_)
 			echo "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersionNumber/jellyfin_$newVersionUnderscore$architecture.tar.gz"
@@ -160,52 +163,69 @@ Download_version()
 
 Version_switch()
 {
-	echo "Current Jellyfin version installed"
-	Get_version
-	echo ""
-	echo "Jellyfin versions already downloaded:"
-	ls /opt/jellyfin/ | grep "_" | cat -n
-	echo
-	echo "Please enter the number corresponding with"
-	read -p "the version you want to install : " versionToSwitchNumber
-	newVersion=$(ls /opt/jellyfin/ | grep "_" | head -n $versionToSwitchNumber | tail -n 1)
-	maxNumber=$(ls /opt/jellyfin/ | grep "_" | wc -l)
-	 if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
-		echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
-	  exit
-	else
-		jellyman -S
-		unlink /opt/jellyfin/jellyfin
-		ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
-		chown -Rfv $defaultUser:$defaultUser /opt/jellyfin/jellyfin
-		Change_variable currentVersion $newVersion
-		jellyman -s
-	fi
+	Has_sudo
+	versionToSwitchNumber=0
+	installedVersions=$(ls /opt/jellyfin/ | grep "_")
+	maxNumber=$(echo $installedVersions | wc -l)
+	warning=
+
+	while [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; do
+		clear
+		echo "Current Jellyfin version installed"
+		Get_version
+		echo
+		echo "Jellyfin versions already downloaded:"
+		echo "$installedVersions" | cat -n
+		echo $warning
+		echo "Please enter the number corresponding with"
+		read -p "the version you want to install : " versionToSwitchNumber
+		newVersion=$(echo $installedVersions | head -n $versionToSwitchNumber | tail -n 1)
+
+		if [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; then
+			warning="ERROR: Please select one of the numbers provided!"
+			echo "Press CTRL+C to exit..."
+		else
+			jellyman -S
+			unlink /opt/jellyfin/jellyfin
+			ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
+			chown -Rfv $defaultUser:$defaultUser /opt/jellyfin/jellyfin
+			Change_variable currentVersion $newVersion
+			jellyman -s
+		fi
+	done
 }
 
 Remove_version()
 {
-	echo "Current Jellyfin version installed"
-	Get_version
-	echo ""
-	echo "Jellyfin versions already downloaded:"
-	ls /opt/jellyfin/ | grep "_" | cat -n
-	echo ""
-	echo "Please enter the number corresponding with"
-	read -p "the version you want to erase : " versionToRemoveNumber
-	maxNumber=$(ls /opt/jellyfin/ | grep "_" | wc -l)
-	versionToRemove=$(ls /opt/jellyfin/ | grep "_" | head -n $versionToRemoveNumber | tail -n 1)
-	if [[ $versionToRemoveNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToRemoveNumber =~ [a-zA-Z]+$ ]] || (( $versionToRemoveNumber > $maxNumber )) || (( $versionToRemoveNumber < 1 )); then
-		echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
-		exit
-	elif isCurrentVersion $versionToRemove; then
-		echo "The version you chose is the currently running version."
-		echo "Please use 'jellyman -vs' and choose a different version,"
-		echo "before removing $versionToRemove"
-		exit
-	else
+	Has_sudo
+	versionToSwitchNumber=0
+	versionToRemove=""
+	installedVersions=$(ls /opt/jellyfin/ | grep "_")
+	maxNumber=$(echo $installedVersions | wc -l)
+	warning=
+
+	while [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; do
+		clear
+		echo "Current Jellyfin version installed"
+		Get_version
+		echo
+		echo "Jellyfin versions already downloaded:"
+		echo "$installedVersions" | cat -n
+		echo
+		echo "$warning"
+		echo "Please enter the number corresponding with"
+		read -p "the version you want to ERASE : " versionToRemoveNumber
+		versionToRemove=$(ehco $installedVersions | head -n $versionToRemoveNumber | tail -n 1)
+		warning="ERROR: Please select one of the numbers provided!"
+		if isCurrentVersion $versionToRemove; then
+			warning="ERROR: v$versionToRemove is the currently running version.
+Please use 'jellyman -vs' and choose a different version,
+before removing v$versionToRemove"
+			versionToRemoveNumber=0
+		fi
+	done
+
 		rm -rfv /opt/jellyfin/$versionToRemove
-	fi
 }
 
 Help()
@@ -339,7 +359,7 @@ Check_api_key()
 	source /opt/jellyfin/config/jellyman.conf
 	if [[ ! -n $apiKey ]]; then
 		echo "***ERROR***"
-		echo "NO API KEY FOUND PLEASE RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
+		echo "NO API KEY FOUND, RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
 		return 1
 		exit
 	else
@@ -542,8 +562,10 @@ Update_beta()
 		if [[ ! $versionSelected == [1-$maxNumber] ]]; then
 			versionSelected=0
 			warning="ERROR: Please select one of the numbers provided!"
+			echo "Press CTRL+C to exit..."
 		elif isCurrentVersion $newVersionName || isInstalledVersion $newVersionName; then
 			warning="ERROR: That Jellyfin version is already installed!"
+			echo "Press CTRL+C to exit..."
 		else
 			newVersionArchive=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1)
 			echo "Getting $newVersionArchive..."
@@ -570,13 +592,13 @@ Is_jellyfin_setup()
 	if [ -f "/opt/jellyfin/config/network.xml" ]; then
 		return 0
 	else
-	echo "|--------------------------------------------------------------|"
-	echo "|                        ***WARNING***                         |"
-	echo "|             JELLYFIN DID NOT GET SET UP PROPERLY!            |"
-	echo "|        NO /opt/jellyfin/config/network.xml FILE FOUND        |"
-	echo "|  This is likely due to not completing the first time setup.  |"
-	echo "|     Navigate to http://localhost:8096/ to complete setup     |"
-	echo "|--------------------------------------------------------------|"
+		echo "|--------------------------------------------------------------|"
+		echo "|                        ***WARNING***                         |"
+		echo "|             JELLYFIN DID NOT GET SET UP PROPERLY!            |"
+		echo "|        NO /opt/jellyfin/config/network.xml FILE FOUND        |"
+		echo "|  This is likely due to not completing the first time setup.  |"
+		echo "|     Navigate to http://localhost:8096/ to complete setup     |"
+		echo "|--------------------------------------------------------------|"
 		return 1
 	fi
 
@@ -609,31 +631,34 @@ Recertify_https()
 
 Rename_tv()
 {
-	clear
 	Has_sudo
 	source /opt/jellyfin/config/jellyman.conf
-	echo "|--------------------------------------------------------------|"
-	echo "|                        ***WARNING***                         |"
-	echo "|       TV SHOW FILE NAMES MUST CONTAIN 'SXXEXX' X=number      |"
-	echo "|                                                              |"
-	echo "|            Please enter the directory to correct             |"
-	echo "|                        For example:                          |"
-	echo "|  /jfin/TV/*/*/* <- For every Episode(May Crash Be Careful!)  |"
-	echo "|                            OR:                               |"
-	echo "|  /jfin/TV/Breaking*Bad/*/* <- For Every Episode in a show    |"
-	echo "|                            OR:                               |"
-	echo "|  /jfin/TV/Breaking*Bad/Season*2/* <- For Every Episode in    |"
-	echo "|                    a season of a show                        |"
-	echo "|                                                              |"
-	echo "|      BE ADVISED, IF YOU'RE RE-NAMING MULTIPLE SHOWS,         |"
-	echo "|             MAKE SURE ALL THE SHOW DIRECTORY                 |"
-	echo "|      NAMES ARE IN THE SAME LOCATION IN THE DIRECTORY         |"
-	echo "|--------------------------------------------------------------|"
-	echo
-	read -p "Please enter a directory : " directoryToCorrect
-	# This is apparently a problem with the next command after clear. --> directoryToCorrect=$(echo $directoryToCorrect | sed -r "s| |*|g")
-	clear
-	nameOfTestFile=$(ls -1 $directoryToCorrect | head -1)
+	nameOfTestFile=""
+
+	while [ ! -f $nameOfTestFile ]; do
+		clear
+		echo "|--------------------------------------------------------------|"
+		echo "|                        ***WARNING***                         |"
+		echo "|       TV SHOW FILE NAMES MUST CONTAIN 'SXXEXX' X=number      |"
+		echo "|                                                              |"
+		echo "|            Please enter the directory to correct             |"
+		echo "|                        For example:                          |"
+		echo "|  /jfin/TV/*/*/* <- For every Episode(May Crash Be Careful!)  |"
+		echo "|                            OR:                               |"
+		echo "|  /jfin/TV/Breaking*Bad/*/* <- For Every Episode in a show    |"
+		echo "|                            OR:                               |"
+		echo "|  /jfin/TV/Breaking*Bad/Season*2/* <- For Every Episode in    |"
+		echo "|                    a season of a show                        |"
+		echo "|                                                              |"
+		echo "|      BE ADVISED, IF YOU'RE RE-NAMING MULTIPLE SHOWS,         |"
+		echo "|             MAKE SURE ALL THE SHOW DIRECTORY                 |"
+		echo "|      NAMES ARE IN THE SAME LOCATION IN THE DIRECTORY         |"
+		echo "|--------------------------------------------------------------|"
+		echo
+		read -p "Please enter a directory : " directoryToCorrect
+		clear
+		nameOfTestFile=$(ls -1 $directoryToCorrect | head -1)
+	done
 	
 	testDirCount=$(echo $nameOfTestFile | grep -o "/" | wc -w)
 
@@ -898,15 +923,50 @@ Update-jellyman()
 Change_Media_Directory()
 {
 	Has_sudo
-	echo "|---------------------------------------------------------|"
-	echo "| Please enter all media directories separated by a space |"
-	echo "|                       example:                          |"
-	echo "|          /media/hdd1/Movies /media/hdd2/TV              |"
-	echo "|---------------------------------------------------------|"
-	echo
-	read mediaPath
+	mediaPath=""
+	warning=""
+	continue=true
+
+	while $continue; do
+		clear
+		echo "|---------------------------------------------------------|"
+		echo "| Please enter all media directories separated by a space |"
+		echo "|                       example:                          |"
+		echo "|          /media/hdd1/Movies /media/hdd2/TV              |"
+		echo "|---------------------------------------------------------|"
+		echo
+		echo $warning
+		read -p "DIRECTORIES: " mediaPath
+		if areDirectories "$mediaPath"; then
+			continue=false
+		else
+			warning="ERROR: Make sure each input is a directory!"
+		fi
+	done
+
 	Change_variable defaultPath "$mediaPath" array
 }
+
+areDirectories()
+{
+	directoriesToCheck="$1"
+	isDirectory=true
+	for item in $directoriesToCheck
+	do
+		if [ ! -d $item ]; then
+			isDirectory=false
+			# echo "$item is not a directory"
+		fi
+	done
+	if $isDirectory; then
+		# echo "$directoriesToCheck are directories"
+		return 0
+	else
+		# echo "$directoriesToCheck are not directories"
+		return 1
+	fi
+}
+
 
 Has_sudo()
 {

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -7,843 +7,843 @@ jellymanVersion="v1.6.4"
 
 Backup()
 {
-   Has_sudo
-   # Backup /opt/jellyfin to passed directory
-   backupDirectory=$1
-   tarPath=
-   fileName=jellyfin-backup.tar
-   mkdir /opt/jellyfin/backup
-   cp /bin/jellyman /opt/jellyfin/backup/
-   cp /etc/jellyfin.conf /opt/jellyfin/backup/
-   cp /usr/lib/systemd/system/jellyfin.service /opt/jellyfin/backup/
-   if [[ $(echo "${backupDirectory: -1}") == "/" ]]; then
-      tarPath=$backupDirectory$fileName
-      echo $tarPath
-   else
-      tarPath=$backupDirectory/$fileName
-      echo $tarPath
-   fi
+	Has_sudo
+	# Backup /opt/jellyfin to passed directory
+	backupDirectory=$1
+	tarPath=
+	fileName=jellyfin-backup.tar
+	mkdir /opt/jellyfin/backup
+	cp /bin/jellyman /opt/jellyfin/backup/
+	cp /etc/jellyfin.conf /opt/jellyfin/backup/
+	cp /usr/lib/systemd/system/jellyfin.service /opt/jellyfin/backup/
+	if [[ $(echo "${backupDirectory: -1}") == "/" ]]; then
+		tarPath=$backupDirectory$fileName
+		echo $tarPath
+	else
+		tarPath=$backupDirectory/$fileName
+		echo $tarPath
+	fi
 
-   time tar cvf $tarPath /opt/jellyfin
-   USER=$(stat -c '%U' $backupDirectory)
-   chown -f $USER:$USER $tarPath
-   chmod -f 660 $tarPath
-   echo "Your backup is:"
-   tarSize=$(du -h $tarPath)
-   echo "Size: $tarSize"
-   echo
-   echo "|--------------------------------------------------------|"
-   echo "|        To Import on your next setup, simply run:       |"
-   echo "|  git clone https://github.com/Smiley-McSmiles/jellyman |"
-   echo "|                       cd jellyman                      |"
-   echo "|                   chmod ug+x setup.sh                  |"
-   echo "|     sudo ./setup.sh -i [Path to jellyfin-backup.tar]   |"
-   echo "|--------------------------------------------------------|"
+	time tar cvf $tarPath /opt/jellyfin
+	USER=$(stat -c '%U' $backupDirectory)
+	chown -f $USER:$USER $tarPath
+	chmod -f 660 $tarPath
+	echo "Your backup is:"
+	tarSize=$(du -h $tarPath)
+	echo "Size: $tarSize"
+	echo
+	echo "|--------------------------------------------------------|"
+	echo "|        To Import on your next setup, simply run:       |"
+	echo "|  git clone https://github.com/Smiley-McSmiles/jellyman |"
+	echo "|                       cd jellyman                      |"
+	echo "|                   chmod ug+x setup.sh                  |"
+	echo "|     sudo ./setup.sh -i [Path to jellyfin-backup.tar]   |"
+	echo "|--------------------------------------------------------|"
 }
 
 Change_variable()
 {
-   varToChange=$1
-   newVarContent=$2
-   varType=$3
-   if [[ $varType == "array" ]]; then
-      newVarContent='"'"$newVarContent"'"'
-   fi
-   
-   if [[ ! -n $varToChange ]] || [[ ! -n $newVarContent ]]; then
-      echo "Function Change_variable requires 2 parameters: varToChange newVarContent"
-      exit
-   else
-      sed -i -e "s|$varToChange=.*|$varToChange=$newVarContent|g" /opt/jellyfin/config/jellyman.conf
-   fi
-   
-   if [[ $varType == "array" ]]; then
-      newArrayVar=$(grep "$varToChange" /opt/jellyfin/config/jellyman.conf | sed -r 's/="/=(/g' | sed -r 's/"/)/g')
-      sed -i -e "s|$varToChange=.*|$newArrayVar|g" /opt/jellyfin/config/jellyman.conf
-   fi
+	varToChange=$1
+	newVarContent=$2
+	varType=$3
+	if [[ $varType == "array" ]]; then
+		newVarContent='"'"$newVarContent"'"'
+	fi
+	
+	if [[ ! -n $varToChange ]] || [[ ! -n $newVarContent ]]; then
+		echo "Function Change_variable requires 2 parameters: varToChange newVarContent"
+		exit
+	else
+		sed -i -e "s|$varToChange=.*|$varToChange=$newVarContent|g" /opt/jellyfin/config/jellyman.conf
+	fi
+	
+	if [[ $varType == "array" ]]; then
+		newArrayVar=$(grep "$varToChange" /opt/jellyfin/config/jellyman.conf | sed -r 's/="/=(/g' | sed -r 's/"/)/g')
+		sed -i -e "s|$varToChange=.*|$newArrayVar|g" /opt/jellyfin/config/jellyman.conf
+	fi
 }
 
 isCurrentVersion()
 {
-   source /opt/jellyfin/config/jellyman.conf
-   jellyfinVersionToDownload=$1
-   if [[ $jellyfinVersionToDownload == $currentVersion ]]; then
-      echo "The installed version of Jellyfin matches the newest version available."
-      echo "Current Jellyfin version installed: $currentVersion"
-      return 0
-   else
-      echo "Newer Jellyfin version found..."
-      return 1
-   fi
+	source /opt/jellyfin/config/jellyman.conf
+	jellyfinVersionToDownload=$1
+	if [[ $jellyfinVersionToDownload == $currentVersion ]]; then
+		echo "The installed version of Jellyfin matches the newest version available."
+		echo "Current Jellyfin version installed: $currentVersion"
+		return 0
+	else
+		echo "Newer Jellyfin version found..."
+		return 1
+	fi
 }
 
 isInstalledVersion()
 {
-   jellyfinVersionToDownload=$1
-   currentJellyfinVersions=$(ls /opt/jellyfin/ | grep "jellyfin_")
-   
-   if [[ $currentJellyfinVersions == *"$jellyfinVersionToDownload"* ]]; then
-      echo "The version to download matches an already installed version."
-      echo "Please use 'jellyman -vs' to switch Jellyfin versions."
-      return 0
-   else
-      return 1
-   fi
+	jellyfinVersionToDownload=$1
+	currentJellyfinVersions=$(ls /opt/jellyfin/ | grep "jellyfin_")
+	
+	if [[ $currentJellyfinVersions == *"$jellyfinVersionToDownload"* ]]; then
+		echo "The version to download matches an already installed version."
+		echo "Please use 'jellyman -vs' to switch Jellyfin versions."
+		return 0
+	else
+		return 1
+	fi
 }
 
 Check_disk_free()
 {
-   source /opt/jellyfin/config/jellyman.conf
-   if [ ! -n $defaultPath ]; then 
-      echo "|-----------------------------------------------|"
-      echo "|          No default directory found...        |"
-      echo "|     Please enter the root directory for       |"
-      echo "|              your Media Library               |"
-      echo "|    DO NOT ENTER YOUR USER DIRECTORY AS IT     |"
-      echo "|    WILL RESET PERMISSIONS OF THE ENTERED      |"
-      echo "|       DIRECTORY TO YOUR JELLYFIN USER         |"
-      echo "|-----------------------------------------------|"
-      read defaultPath
-      defaultPath=($defaultPath)
-      Change_variable defaultPath $defaultPath
-      df -h ${defaultPath[*]}
-   else 
-      df -h ${defaultPath[*]}
-   fi
+	source /opt/jellyfin/config/jellyman.conf
+	if [ ! -n $defaultPath ]; then 
+		echo "|-----------------------------------------------|"
+		echo "|          No default directory found...        |"
+		echo "|     Please enter the root directory for       |"
+		echo "|              your Media Library               |"
+		echo "|    DO NOT ENTER YOUR USER DIRECTORY AS IT     |"
+		echo "|    WILL RESET PERMISSIONS OF THE ENTERED      |"
+		echo "|       DIRECTORY TO YOUR JELLYFIN USER         |"
+		echo "|-----------------------------------------------|"
+		read defaultPath
+		defaultPath=($defaultPath)
+		Change_variable defaultPath $defaultPath
+		df -h ${defaultPath[*]}
+	else 
+		df -h ${defaultPath[*]}
+	fi
 }
 
 Get_jellyfin_version()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   echo "$currentVersion"
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	echo "$currentVersion"
 }
 
 Get_jellyman_version()
 {
-   echo "Jellyman $jellymanVersion"
+	echo "Jellyman $jellymanVersion"
 }
 
 Download_version()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   mkdir /opt/jellyfin/update
-   wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/
-   cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n
-   echo
-   echo "Please enter the number corresponding with"
-   read -p "the version you want to install : " versionToSwitchNumber
-   newVersion=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | head -n $versionToSwitchNumber | tail -n 1)
-   maxNumber=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | wc -l)
-    if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
-      echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
-     exit
-   else
-      newVersionUnderscore=$(echo "$newVersion"_)
-      echo "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
-      jellyman -u "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
-   fi
-   rm -fv /opt/jellyfin/update/index.html
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	mkdir /opt/jellyfin/update
+	wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/
+	cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n
+	echo
+	echo "Please enter the number corresponding with"
+	read -p "the version you want to install : " versionToSwitchNumber
+	newVersion=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | head -n $versionToSwitchNumber | tail -n 1)
+	maxNumber=$(cat /opt/jellyfin/update/index.html | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | wc -l)
+	 if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
+		echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
+	  exit
+	else
+		newVersionUnderscore=$(echo "$newVersion"_)
+		echo "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
+		jellyman -u "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
+	fi
+	rm -fv /opt/jellyfin/update/index.html
 }
 
 Version_switch()
 {
-   echo "Current Jellyfin version installed"
-   Get_version
-   echo ""
-   echo "Jellyfin versions already downloaded:"
-   ls /opt/jellyfin/ | grep "_" | cat -n
-   echo
-   echo "Please enter the number corresponding with"
-   read -p "the version you want to install : " versionToSwitchNumber
-   newVersion=$(ls /opt/jellyfin/ | grep "_" | head -n $versionToSwitchNumber | tail -n 1)
-   maxNumber=$(ls /opt/jellyfin/ | grep "_" | wc -l)
-    if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
-      echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
-     exit
-   else
-      jellyman -S
-      unlink /opt/jellyfin/jellyfin
-      ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
-      chown -Rfv $defaultUser:$defaultUser /opt/jellyfin/jellyfin
-      Change_variable currentVersion $newVersion
-      jellyman -s
-   fi
+	echo "Current Jellyfin version installed"
+	Get_version
+	echo ""
+	echo "Jellyfin versions already downloaded:"
+	ls /opt/jellyfin/ | grep "_" | cat -n
+	echo
+	echo "Please enter the number corresponding with"
+	read -p "the version you want to install : " versionToSwitchNumber
+	newVersion=$(ls /opt/jellyfin/ | grep "_" | head -n $versionToSwitchNumber | tail -n 1)
+	maxNumber=$(ls /opt/jellyfin/ | grep "_" | wc -l)
+	 if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
+		echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
+	  exit
+	else
+		jellyman -S
+		unlink /opt/jellyfin/jellyfin
+		ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
+		chown -Rfv $defaultUser:$defaultUser /opt/jellyfin/jellyfin
+		Change_variable currentVersion $newVersion
+		jellyman -s
+	fi
 }
 
 Remove_version()
 {
-   echo "Current Jellyfin version installed"
-   Get_version
-   echo ""
-   echo "Jellyfin versions already downloaded:"
-   ls /opt/jellyfin/ | grep "_" | cat -n
-   echo ""
-   echo "Please enter the number corresponding with"
-   read -p "the version you want to erase : " versionToRemoveNumber
-   maxNumber=$(ls /opt/jellyfin/ | grep "_" | wc -l)
-   versionToRemove=$(ls /opt/jellyfin/ | grep "_" | head -n $versionToRemoveNumber | tail -n 1)
-   if [[ $versionToRemoveNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToRemoveNumber =~ [a-zA-Z]+$ ]] || (( $versionToRemoveNumber > $maxNumber )) || (( $versionToRemoveNumber < 1 )); then
-      echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
-      exit
-   elif isCurrentVersion $versionToRemove; then
-      echo "The version you chose is the currently running version."
-      echo "Please use 'jellyman -vs' and choose a different version,"
-      echo "before removing $versionToRemove"
-      exit
-   else
-      rm -rfv /opt/jellyfin/$versionToRemove
-   fi
+	echo "Current Jellyfin version installed"
+	Get_version
+	echo ""
+	echo "Jellyfin versions already downloaded:"
+	ls /opt/jellyfin/ | grep "_" | cat -n
+	echo ""
+	echo "Please enter the number corresponding with"
+	read -p "the version you want to erase : " versionToRemoveNumber
+	maxNumber=$(ls /opt/jellyfin/ | grep "_" | wc -l)
+	versionToRemove=$(ls /opt/jellyfin/ | grep "_" | head -n $versionToRemoveNumber | tail -n 1)
+	if [[ $versionToRemoveNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToRemoveNumber =~ [a-zA-Z]+$ ]] || (( $versionToRemoveNumber > $maxNumber )) || (( $versionToRemoveNumber < 1 )); then
+		echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
+		exit
+	elif isCurrentVersion $versionToRemove; then
+		echo "The version you chose is the currently running version."
+		echo "Please use 'jellyman -vs' and choose a different version,"
+		echo "before removing $versionToRemove"
+		exit
+	else
+		rm -rfv /opt/jellyfin/$versionToRemove
+	fi
 }
 
 Help()
 {
-   # Display Help
-   echo "Jellyman - The Jellyfin Manager $jellymanVersion"
-   echo "-Created by Smiley McSmiles"
-   echo 
-   echo "Syntax: jellyman -[COMMAND] [PARAMETER]"
-   echo "COMMANDS:"
-   echo "-b     [DIRECTORY] Input directory to output backup archive."
-   echo "-d     Disable Jellyfin on System Start."
-   echo "-e     Enable Jellyfin on System Start."
-   echo "-h     Print this Help."
-   echo "-i     [FILE.tar] Input file to Import jellyfin-backup.tar."
-   echo "-p     [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory."
-   echo "-r     Restart Jellyfin."
-   echo "-s     Start Jellyfin."
-   echo "-S     Stop Jellyfin."
-   echo "-t     Status of Jellyfin."
-   echo "-u     [URL - optional] Downloads and updates the current stable or supplied Jellyfin version."
-   echo "-U     Update Jellyman - The Jellyfin Manager."
-   echo "-ub    Update Jellyfin to the most recent Beta."
-   echo "-v     Get the current installed version of Jellyfin."
-   echo "-vd    Download an available Jellyfin version from the stable repository."
-   echo "-vs    Switch Jellyfin version for another previously installed version."
-   echo "-rv    Remove a Jellyfin version."
-   echo "-rc    Removes old https certifications and creates new ones for the next 365 days."
-   echo "-rn    Batch renaming script for TV shows."
-   echo "-ls    Tell Jellyfin to scan your media library."
-   echo "-cp    Change Jellyfins http network port - Default = 8096"
-   echo "-cps   Change Jellyfins https network port - Default = 8920."
-   echo "-ik    Import an API key"
-   echo "-md    Change the Media Directory for Jellyman."
-   echo "-tc    Transcode a file/directory with a GB per hour filter (1.5GB is recommended)"
-   echo "-X     Uninstall Jellyfin and Jellyman Completely."
-   echo
-   echo "To browse Jellyfin versions please use this link."
-   echo "***WARNING*** ONLY USE COMBINED(Web & Server) PACKAGES"
-   echo "https://repo.jellyfin.org/releases/server/linux/versions/"
+	# Display Help
+	echo "Jellyman - The Jellyfin Manager $jellymanVersion"
+	echo "-Created by Smiley McSmiles"
+	echo 
+	echo "Syntax: jellyman -[COMMAND] [PARAMETER]"
+	echo "COMMANDS:"
+	echo "-b     [DIRECTORY] Input directory to output backup archive."
+	echo "-d     Disable Jellyfin on System Start."
+	echo "-e     Enable Jellyfin on System Start."
+	echo "-h     Print this Help."
+	echo "-i     [FILE.tar] Input file to Import jellyfin-backup.tar."
+	echo "-p     [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory."
+	echo "-r     Restart Jellyfin."
+	echo "-s     Start Jellyfin."
+	echo "-S     Stop Jellyfin."
+	echo "-t     Status of Jellyfin."
+	echo "-u     [URL - optional] Downloads and updates the current stable or supplied Jellyfin version."
+	echo "-U     Update Jellyman - The Jellyfin Manager."
+	echo "-ub    Update Jellyfin to the most recent Beta."
+	echo "-v     Get the current installed version of Jellyfin."
+	echo "-vd    Download an available Jellyfin version from the stable repository."
+	echo "-vs    Switch Jellyfin version for another previously installed version."
+	echo "-rv    Remove a Jellyfin version."
+	echo "-rc    Removes old https certifications and creates new ones for the next 365 days."
+	echo "-rn    Batch renaming script for TV shows."
+	echo "-ls    Tell Jellyfin to scan your media library."
+	echo "-cp    Change Jellyfins http network port - Default = 8096"
+	echo "-cps   Change Jellyfins https network port - Default = 8920."
+	echo "-ik    Import an API key"
+	echo "-md    Change the Media Directory for Jellyman."
+	echo "-tc    Transcode a file/directory with a GB per hour filter (1.5GB is recommended)"
+	echo "-X     Uninstall Jellyfin and Jellyman Completely."
+	echo
+	echo "To browse Jellyfin versions please use this link."
+	echo "***WARNING*** ONLY USE COMBINED(Web & Server) PACKAGES"
+	echo "https://repo.jellyfin.org/releases/server/linux/versions/"
 }
 
 Import()
 {
-   Has_sudo
-   #Import jellyfin-backup.tar
-   importTar=$1
-   echo "******WARNING******"
-   echo "******CAUTION******"
-   echo "This procedure should only be used as a fresh install of Jellyfin."
-   echo "As this procedure will erase /opt/jellyfin COMPLETELY."
-   sleep 5
-   read -p "...Continue? [yes/No] :" importOrNotToImport
-   if [[ $importOrNotToImport == [yY][eE][sS] ]]; then
-      echo "IMPORTING $importTar"
-      jellyman -S
-      rm -rf /opt/jellyfin
-      tar xvf $importTar -C /
-      clear
-      source /opt/jellyfin/config/jellyman.conf
-      mv -f /opt/jellyfin/backup/jellyfin /bin/
-      chmod +x /bin/jellyman
-      mv -f /opt/jellyfin/backup/jellyfin.service /usr/lib/systemd/system/
-      mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
-      if id "$defaultUser" &>/dev/null; then 
-         chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-         chmod -Rfv 770 /opt/jellyfin
-         jellyman -s -t
-      else
-         clear
-         echo "|------------------------------------------------------------------|"
-         echo "|                       *******ERROR*******                        |"
-         echo "|   The imported default Jellyfin user($defaultUser) has not yet   |"
-         echo "|   been created. This error is likely due to a read error of the  |"
-         echo "|            /opt/jellyfin/config/jellyman.conf file.              |"
-         echo "|  The default user is usually created by jellyman - The CLI Tool, |"
-         echo "|                   when running setup.sh.                         |"
-         echo "|    You may want to see who owns that configuration file with:    |"
-         echo "|            'ls /opt/jellyfin/config/jellyman.conf'               |"
-         echo "|------------------------------------------------------------------|"
-         echo
-         read -p "...Continue with $defaultUser? [yes/No] :" newUserOrOld
-         if [[ $newUserOrOld == [yY][eE][sS] ]]; then
-            echo "Great!"
-            sleep .5
-            chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-            chmod -Rfv 770 /opt/jellyfin
-            jellyman -s -t
-         else
-            read -p "No? Which user should own /opt/jellyfin?: " defaultUser
-            echo "Well... I should've known $defaultUser would be the one..."
-            sleep 1
-            chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-            chmod -Rfv 770 /opt/jellyfin
-            jellyman -s -t
-         fi
-      fi
+	Has_sudo
+	#Import jellyfin-backup.tar
+	importTar=$1
+	echo "******WARNING******"
+	echo "******CAUTION******"
+	echo "This procedure should only be used as a fresh install of Jellyfin."
+	echo "As this procedure will erase /opt/jellyfin COMPLETELY."
+	sleep 5
+	read -p "...Continue? [yes/No] :" importOrNotToImport
+	if [[ $importOrNotToImport == [yY][eE][sS] ]]; then
+		echo "IMPORTING $importTar"
+		jellyman -S
+		rm -rf /opt/jellyfin
+		tar xvf $importTar -C /
+		clear
+		source /opt/jellyfin/config/jellyman.conf
+		mv -f /opt/jellyfin/backup/jellyfin /bin/
+		chmod +x /bin/jellyman
+		mv -f /opt/jellyfin/backup/jellyfin.service /usr/lib/systemd/system/
+		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
+		if id "$defaultUser" &>/dev/null; then 
+			chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
+			chmod -Rfv 770 /opt/jellyfin
+			jellyman -s -t
+		else
+			clear
+			echo "|------------------------------------------------------------------|"
+			echo "|                       *******ERROR*******                        |"
+			echo "|   The imported default Jellyfin user($defaultUser) has not yet   |"
+			echo "|   been created. This error is likely due to a read error of the  |"
+			echo "|            /opt/jellyfin/config/jellyman.conf file.              |"
+			echo "|  The default user is usually created by jellyman - The CLI Tool, |"
+			echo "|                   when running setup.sh.                         |"
+			echo "|    You may want to see who owns that configuration file with:    |"
+			echo "|            'ls /opt/jellyfin/config/jellyman.conf'               |"
+			echo "|------------------------------------------------------------------|"
+			echo
+			read -p "...Continue with $defaultUser? [yes/No] :" newUserOrOld
+			if [[ $newUserOrOld == [yY][eE][sS] ]]; then
+				echo "Great!"
+				sleep .5
+				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rfv 770 /opt/jellyfin
+				jellyman -s -t
+			else
+				read -p "No? Which user should own /opt/jellyfin?: " defaultUser
+				echo "Well... I should've known $defaultUser would be the one..."
+				sleep 1
+				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rfv 770 /opt/jellyfin
+				jellyman -s -t
+			fi
+		fi
 
-   else
-      echo "Returning..."
-   fi    
+	else
+		echo "Returning..."
+	fi	 
 }
 
 Library_scan()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   Check_api_key
-   curl -d POST http://localhost:$networkPort/Library/Refresh?api_key=$apiKey
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	Check_api_key
+	curl -d POST http://localhost:$networkPort/Library/Refresh?api_key=$apiKey
 }
 
 Import_api_key()
 {
-   Has_sudo
-   echo "Create a API key by signing into Jellyfin, going to Dashboard, then"
-   echo "clicking on API Keys under the Advanced section on the left."
-   echo
-   read -p "Please paste your API Key : " newAPIKey
-   if [[ -n $newAPIKey ]]; then
-      echo "Logging new api key."
-      Change_variable apiKey $newAPIKey
-   else
-      echo "Warning no input detected, please re-enter the command and paste an API key"
-      exit
-   fi
+	Has_sudo
+	echo "Create a API key by signing into Jellyfin, going to Dashboard, then"
+	echo "clicking on API Keys under the Advanced section on the left."
+	echo
+	read -p "Please paste your API Key : " newAPIKey
+	if [[ -n $newAPIKey ]]; then
+		echo "Logging new api key."
+		Change_variable apiKey $newAPIKey
+	else
+		echo "Warning no input detected, please re-enter the command and paste an API key"
+		exit
+	fi
 }
 
 Check_api_key()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   if [[ ! -n $apiKey ]]; then
-      echo "***ERROR***"
-      echo "NO API KEY FOUND PLEASE RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
-      return 1
-      exit
-   else
-      return 0
-   fi
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	if [[ ! -n $apiKey ]]; then
+		echo "***ERROR***"
+		echo "NO API KEY FOUND PLEASE RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
+		return 1
+		exit
+	else
+		return 0
+	fi
 }
 
 Http_port_change()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   echo
-   echo "Default http port is 8096"
-   if Is_jellyfin_setup; then
-      read -p "Please enter the new http network port for Jellyfin: " port
-      Change_variable httpPort $port
-      sed -i -e "s|<HttpServerPortNumber>*</HttpServerPortNumber>|<HttpServerPortNumber>$port</HttpServerPortNumber>|g" /opt/jellyfin/config/network.xml
-      sed -i -e "s|<PublicPort>*</PublicPort>|<PublicPort>$port</PublicPort>|g" /opt/jellyfin/config/network.xml
-      echo "Unblocking port $port..."
-      if [ -x "$(command -v ufw)" ]; then
-         ufw allow $port
-         ufw reload
-      elif [ -x "$(command -v firewall-cmd)" ]; then 
-         firewall-cmd --permanent --zone=public --add-port=$port/tcp
-         firewall-cmd --reload
-      else
-         echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
-      fi
-   else
-      exit
-   fi
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	echo
+	echo "Default http port is 8096"
+	if Is_jellyfin_setup; then
+		read -p "Please enter the new http network port for Jellyfin: " port
+		Change_variable httpPort $port
+		sed -i -e "s|<HttpServerPortNumber>*</HttpServerPortNumber>|<HttpServerPortNumber>$port</HttpServerPortNumber>|g" /opt/jellyfin/config/network.xml
+		sed -i -e "s|<PublicPort>*</PublicPort>|<PublicPort>$port</PublicPort>|g" /opt/jellyfin/config/network.xml
+		echo "Unblocking port $port..."
+		if [ -x "$(command -v ufw)" ]; then
+			ufw allow $port
+			ufw reload
+		elif [ -x "$(command -v firewall-cmd)" ]; then 
+			firewall-cmd --permanent --zone=public --add-port=$port/tcp
+			firewall-cmd --reload
+		else
+			echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
+		fi
+	else
+		exit
+	fi
 }
 
 Https_port_change()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   if Is_jellyfin_setup; then
-      echo "Default https port is 8920"
-      read -p "Please enter the new https network port for Jellyfin: " port
-      Change_variable httpsPort $port
-      sed -i -e "s|<HttpsServerPortNumber>*</HttpsServerPortNumber>|<HttpsServerPortNumber>$port</HttpsServerPortNumber>|g" /opt/jellyfin/config/network.xml
-      sed -i -e "s|<PublicHttpsPort>*</PublicHttpsPort>|<PublicHttpsPort>$port</PublicHttpsPort>|g" /opt/jellyfin/config/network.xml
-      echo "Unblocking port $port..."
-      if [ -x "$(command -v ufw)" ]; then
-         ufw allow $port
-         ufw reload
-      elif [ -x "$(command -v firewall-cmd)" ]; then 
-         firewall-cmd --permanent --zone=public --add-port=$port/tcp
-         firewall-cmd --reload
-      else
-         echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
-      fi
-   else
-      exit
-   fi
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	if Is_jellyfin_setup; then
+		echo "Default https port is 8920"
+		read -p "Please enter the new https network port for Jellyfin: " port
+		Change_variable httpsPort $port
+		sed -i -e "s|<HttpsServerPortNumber>*</HttpsServerPortNumber>|<HttpsServerPortNumber>$port</HttpsServerPortNumber>|g" /opt/jellyfin/config/network.xml
+		sed -i -e "s|<PublicHttpsPort>*</PublicHttpsPort>|<PublicHttpsPort>$port</PublicHttpsPort>|g" /opt/jellyfin/config/network.xml
+		echo "Unblocking port $port..."
+		if [ -x "$(command -v ufw)" ]; then
+			ufw allow $port
+			ufw reload
+		elif [ -x "$(command -v firewall-cmd)" ]; then 
+			firewall-cmd --permanent --zone=public --add-port=$port/tcp
+			firewall-cmd --reload
+		else
+			echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
+		fi
+	else
+		exit
+	fi
 }
 
 
 Permissions()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   checkForDefaultPath="yes"
-   directoryToFix=
-   if [[ "$1" == "/"* ]]; then
-      directoryToFix=$1
-   elif [[ "$1" == *"/" ]]; then
-      echo "$1 is not a directory. Please enter a absolute path to your media"
-      echo "EXITING..."
-      exit
-   else
-      #Check if there is a recorded media library path for chown and chmod:
-      if [[ ! -n $defaultPath ]] ; then 
-         echo "No default directory found..."
-         echo "Please enter the root directory for your Media Library..."
-         echo "If multiple paths please enter all paths separated by a space"
-         read defaultPath
-         Change_variable defaultPath "$defaultPath" "array"
-      else 
-         echo "defaultPath is set to ${defaultPath[*]}"
-      fi
-      #Check if there is a recorded user/group for chown and chmod:
-      if id "$defaultUser" &>/dev/null; then
-         echo "defaultUser is set to $defaultUser"
-      else
-         echo "No default user found..."
-         echo "Please enter the owner for this directory..."
-         read defaultUser
-         Change_variable defaultUser $defaultUser
-      fi
-      chown -Rfv $defaultUser:$defaultUser ${defaultPath[*]}
-      chmod -Rfv 770 ${defaultPath[*]}
-   fi
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	checkForDefaultPath="yes"
+	directoryToFix=
+	if [[ "$1" == "/"* ]]; then
+		directoryToFix=$1
+	elif [[ "$1" == *"/" ]]; then
+		echo "$1 is not a directory. Please enter a absolute path to your media"
+		echo "EXITING..."
+		exit
+	else
+		#Check if there is a recorded media library path for chown and chmod:
+		if [[ ! -n $defaultPath ]] ; then 
+			echo "No default directory found..."
+			echo "Please enter the root directory for your Media Library..."
+			echo "If multiple paths please enter all paths separated by a space"
+			read defaultPath
+			Change_variable defaultPath "$defaultPath" "array"
+		else 
+			echo "defaultPath is set to ${defaultPath[*]}"
+		fi
+		#Check if there is a recorded user/group for chown and chmod:
+		if id "$defaultUser" &>/dev/null; then
+			echo "defaultUser is set to $defaultUser"
+		else
+			echo "No default user found..."
+			echo "Please enter the owner for this directory..."
+			read defaultUser
+			Change_variable defaultUser $defaultUser
+		fi
+		chown -Rfv $defaultUser:$defaultUser ${defaultPath[*]}
+		chmod -Rfv 770 ${defaultPath[*]}
+	fi
 
-   chown -Rfv $defaultUser:$defaultUser "$directoryToFix"
-   chmod -Rfv 770 "$directoryToFix"
+	chown -Rfv $defaultUser:$defaultUser "$directoryToFix"
+	chmod -Rfv 770 "$directoryToFix"
 }
 
 Status()
 {
-   Check_disk_free
-   echo
-   echo
-   systemctl status jellyfin.service
+	Check_disk_free
+	echo
+	echo
+	systemctl status jellyfin.service
 }
 
 Update()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   customVersionLink=
-   customVersion=""
-   fileType=""
-   jellyfin_archive=""
-   jellyfin=""
-   new_jellyfin_version=""
-   
-   if [[ $1 == *"://"* ]] ; then 
-      echo "Fetching custom Jellyfin version..."
-      customVersionLink=$1
-      customVersion=$(echo $customVersionLink | rev | cut -d/ -f1 | rev)
-      jellyfin_archive=$customVersion
-      jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-      fileType=$(echo $customVersion | cut -d_ -f3)
-      
-      if isInstalledVersion $jellyfin; then
-         exit
-      fi
-      
-      if [[ $fileType != "$architecture.tar.gz" ]]; then
-         echo "Supplied URL does not point to a $architecture.tar.gz.. EXITING..."
-         exit
-      fi
-   
-      mkdir /opt/jellyfin/update
-      wget -P /opt/jellyfin/update/ $customVersionLink
-   
-   else
-      echo "Getting current version from repository..."
-      mkdir /opt/jellyfin/update
-      wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/stable/combined/
-      jellyfin_archive=$(grep "$architecture.tar.gz" /opt/jellyfin/update/index.html | cut -d '"' -f 2 | head -1 | sed -r "s|.sha256sum||g" | sed -r "s|-musl||g")
-      jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-      rm -f /opt/jellyfin/update/index.html
-      
-      echo "jellyfin_archive = $jellyfin_archive"
-      echo "jellyfin = $jellyfin"
-      echo "currentVersion = $currentVersion"
-      if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
-         wget -O /opt/jellyfin/update/$jellyfin_archive https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
-      else
-         exit
-      fi
-   fi
-   
-   new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
-   echo "Unpacking $jellyfin_archive to /opt/jellyfin/..."
-   tar xvzf /opt/jellyfin/update/$jellyfin_archive -C /opt/jellyfin/
-   jellyman -S
-   unlink /opt/jellyfin/jellyfin
-   ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
-   echo "Removing $jellyfin_archive"
-   rm -rfv /opt/jellyfin/update
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	customVersionLink=
+	customVersion=""
+	fileType=""
+	jellyfin_archive=""
+	jellyfin=""
+	new_jellyfin_version=""
+	
+	if [[ $1 == *"://"* ]] ; then 
+		echo "Fetching custom Jellyfin version..."
+		customVersionLink=$1
+		customVersion=$(echo $customVersionLink | rev | cut -d/ -f1 | rev)
+		jellyfin_archive=$customVersion
+		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
+		fileType=$(echo $customVersion | cut -d_ -f3)
+		
+		if isInstalledVersion $jellyfin; then
+			exit
+		fi
+		
+		if [[ $fileType != "$architecture.tar.gz" ]]; then
+			echo "Supplied URL does not point to a $architecture.tar.gz.. EXITING..."
+			exit
+		fi
+	
+		mkdir /opt/jellyfin/update
+		wget -P /opt/jellyfin/update/ $customVersionLink
+	
+	else
+		echo "Getting current version from repository..."
+		mkdir /opt/jellyfin/update
+		wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/stable/combined/
+		jellyfin_archive=$(grep "$architecture.tar.gz" /opt/jellyfin/update/index.html | cut -d '"' -f 2 | head -1 | sed -r "s|.sha256sum||g" | sed -r "s|-musl||g")
+		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
+		rm -f /opt/jellyfin/update/index.html
+		
+		echo "jellyfin_archive = $jellyfin_archive"
+		echo "jellyfin = $jellyfin"
+		echo "currentVersion = $currentVersion"
+		if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
+			wget -O /opt/jellyfin/update/$jellyfin_archive https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
+		else
+			exit
+		fi
+	fi
+	
+	new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
+	echo "Unpacking $jellyfin_archive to /opt/jellyfin/..."
+	tar xvzf /opt/jellyfin/update/$jellyfin_archive -C /opt/jellyfin/
+	jellyman -S
+	unlink /opt/jellyfin/jellyfin
+	ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
+	echo "Removing $jellyfin_archive"
+	rm -rfv /opt/jellyfin/update
 
-   chown -R $defaultUser:$defaultUser /opt/jellyfin
-   echo "Jellyfin updated to version $new_jellyfin_version"
-   Change_variable currentVersion $jellyfin
-   jellyman -s -t
+	chown -R $defaultUser:$defaultUser /opt/jellyfin
+	echo "Jellyfin updated to version $new_jellyfin_version"
+	Change_variable currentVersion $jellyfin
+	jellyman -s -t
 }
 
 
 Update_beta()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   jellyfin_archive=""
-   jellyfin=""
-   new_jellyfin_version=""
-   
-   echo "Fetching newest beta Jellyfin version..."
-   mkdir /opt/jellyfin/update
-   wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/stable-pre/
-   jellyfin_archive=$(grep "$architecture.tar.gz" /opt/jellyfin/update/index.html | grep 'combined' | cut -d '/' -f5 | cut -d '<' -f1 | head -n 1 | sed -r "s|.sha256sum||g")
-   jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-   new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
-   if [[ ! -n $jellyfin_archive ]] || [[ ! -n $jellyfin ]]; then
-      echo "Sorry there appears to be no Jellyfin Betas right now..."
-      exit
-   else
-      rm -f /opt/jellyfin/update/index.html
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	jellyfin_archive=""
+	jellyfin=""
+	new_jellyfin_version=""
+	
+	echo "Fetching newest beta Jellyfin version..."
+	mkdir /opt/jellyfin/update
+	wget -O /opt/jellyfin/update/index.html https://repo.jellyfin.org/releases/server/linux/stable-pre/
+	jellyfin_archive=$(grep "$architecture.tar.gz" /opt/jellyfin/update/index.html | grep 'combined' | cut -d '/' -f5 | cut -d '<' -f1 | head -n 1 | sed -r "s|.sha256sum||g")
+	jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
+	new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
+	if [[ ! -n $jellyfin_archive ]] || [[ ! -n $jellyfin ]]; then
+		echo "Sorry there appears to be no Jellyfin Betas right now..."
+		exit
+	else
+		rm -f /opt/jellyfin/update/index.html
 
-      if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
-         wget -O /opt/jellyfin/update/$jellyfin_archive https://repo.jellyfin.org/releases/server/linux/stable-pre/$new_jellyfin_version/combined/$jellyfin_archive
-      else
-         exit
-      fi
+		if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
+			wget -O /opt/jellyfin/update/$jellyfin_archive https://repo.jellyfin.org/releases/server/linux/stable-pre/$new_jellyfin_version/combined/$jellyfin_archive
+		else
+			exit
+		fi
 
 
-      echo "Unpacking $jellyfin_archive to /opt/jellyfin/..."
-      tar xvzf /opt/jellyfin/update/$jellyfin_archive -C /opt/jellyfin/
-      jellyman -S
-      unlink /opt/jellyfin/jellyfin
-      ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
-      echo "Removing $jellyfin_archive"
-      rm -rfv /opt/jellyfin/update
+		echo "Unpacking $jellyfin_archive to /opt/jellyfin/..."
+		tar xvzf /opt/jellyfin/update/$jellyfin_archive -C /opt/jellyfin/
+		jellyman -S
+		unlink /opt/jellyfin/jellyfin
+		ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
+		echo "Removing $jellyfin_archive"
+		rm -rfv /opt/jellyfin/update
 
-      chown -R $defaultUser:$defaultUser /opt/jellyfin
-      echo "Jellyfin updated to version $new_jellyfin_version"
-      Change_variable currentVersion $jellyfin
-      jellyman -s -t
-   fi
+		chown -R $defaultUser:$defaultUser /opt/jellyfin
+		echo "Jellyfin updated to version $new_jellyfin_version"
+		Change_variable currentVersion $jellyfin
+		jellyman -s -t
+	fi
 }
 
 Is_jellyfin_setup()
 {
-   if [ -f "/opt/jellyfin/config/network.xml" ]; then
-      return 0
-   else
-      echo "|--------------------------------------------------------------|"
-      echo "|                        ***WARNING***                         |"
-      echo "|             JELLYFIN DID NOT GET SET UP PROPERLY!            |"
-      echo "|        NO /opt/jellyfin/config/network.xml FILE FOUND        |"
-      echo "|  This is likely due to not completing the first time setup.  |"
-      echo "|     Navigate to http://localhost:8096/ to complete setup     |"
-      echo "|--------------------------------------------------------------|"
-      return 1
-   fi
+	if [ -f "/opt/jellyfin/config/network.xml" ]; then
+		return 0
+	else
+	echo "|--------------------------------------------------------------|"
+	echo "|                        ***WARNING***                         |"
+	echo "|             JELLYFIN DID NOT GET SET UP PROPERLY!            |"
+	echo "|        NO /opt/jellyfin/config/network.xml FILE FOUND        |"
+	echo "|  This is likely due to not completing the first time setup.  |"
+	echo "|     Navigate to http://localhost:8096/ to complete setup     |"
+	echo "|--------------------------------------------------------------|"
+		return 1
+	fi
 
 }
 
 Recertify_https()
 {
-   Has_sudo
-   echo "|------------------------------------------------------|"
-   echo "|  Creating OpenSSL self signed certificate for https. |"
-   echo "|             Valid for the next 365 days.             |"
-   echo "|       This only works if you have completed          |" 
-   echo "|           first time setup in Jellyfin               |"
-   echo "|------------------------------------------------------|"
-   source /opt/jellyfin/config/jellyman.conf
-   if Is_jellyfin_setup; then
-      rm -fv /opt/jellyfin/cert/*
-      openssl req -x509 -newkey rsa:4096 -keyout /opt/jellyfin/cert/privkey.pem -out /opt/jellyfin/cert/cert.pem -days 365 -nodes -subj '/CN=jellyfin.lan'
-      openssl pkcs12 -export -out /opt/jellyfin/cert/jellyfin.pfx -inkey /opt/jellyfin/cert/privkey.pem -in /opt/jellyfin/cert/cert.pem -passout pass:
-      echo "Enabling https..."
-      sed -i -e "s|<EnableHttps>*</EnableHttps>|<EnableHttps>true</EnableHttps>|g" /opt/jellyfin/config/network.xml
-      sed -i -e "s|<CertificatePath>*</CertificatePath>|<CertificatePath>/opt/jellyfin/cert/jellyfin.pfx</CertificatePath>|g" /opt/jellyfin/config/network.xml
-      chown -Rf $defaultUser:$defaultUser /opt/jellyfin/cert
-      chmod -Rf 770 /opt/jellyfin/cert
-      jellyman -r
-   else
-      exit
-   fi
+	Has_sudo
+	echo "|------------------------------------------------------|"
+	echo "|  Creating OpenSSL self signed certificate for https. |"
+	echo "|             Valid for the next 365 days.             |"
+	echo "|       This only works if you have completed          |" 
+	echo "|           first time setup in Jellyfin               |"
+	echo "|------------------------------------------------------|"
+	source /opt/jellyfin/config/jellyman.conf
+	if Is_jellyfin_setup; then
+		rm -fv /opt/jellyfin/cert/*
+		openssl req -x509 -newkey rsa:4096 -keyout /opt/jellyfin/cert/privkey.pem -out /opt/jellyfin/cert/cert.pem -days 365 -nodes -subj '/CN=jellyfin.lan'
+		openssl pkcs12 -export -out /opt/jellyfin/cert/jellyfin.pfx -inkey /opt/jellyfin/cert/privkey.pem -in /opt/jellyfin/cert/cert.pem -passout pass:
+		echo "Enabling https..."
+		sed -i -e "s|<EnableHttps>*</EnableHttps>|<EnableHttps>true</EnableHttps>|g" /opt/jellyfin/config/network.xml
+		sed -i -e "s|<CertificatePath>*</CertificatePath>|<CertificatePath>/opt/jellyfin/cert/jellyfin.pfx</CertificatePath>|g" /opt/jellyfin/config/network.xml
+		chown -Rf $defaultUser:$defaultUser /opt/jellyfin/cert
+		chmod -Rf 770 /opt/jellyfin/cert
+		jellyman -r
+	else
+		exit
+	fi
 }
 
 Rename_tv()
 {
-   clear
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   echo "|--------------------------------------------------------------|"
-   echo "|                        ***WARNING***                         |"
-   echo "|       TV SHOW FILE NAMES MUST CONTAIN 'SXXEXX' X=number      |"
-   echo "|                                                              |"
-   echo "|            Please enter the directory to correct             |"
-   echo "|                        For example:                          |"
-   echo "|  /jfin/TV/*/*/* <- For every Episode(May Crash Be Careful!)  |"
-   echo "|                            OR:                               |"
-   echo "|  /jfin/TV/Breaking*Bad/*/* <- For Every Episode in a show    |"
-   echo "|                            OR:                               |"
-   echo "|  /jfin/TV/Breaking*Bad/Season*2/* <- For Every Episode in    |"
-   echo "|                    a season of a show                        |"
-   echo "|                                                              |"
-   echo "|      BE ADVISED, IF YOU'RE RE-NAMING MULTIPLE SHOWS,         |"
-   echo "|             MAKE SURE ALL THE SHOW DIRECTORY                 |"
-   echo "|      NAMES ARE IN THE SAME LOCATION IN THE DIRECTORY         |"
-   echo "|--------------------------------------------------------------|"
-   echo
-   read -p "Please enter a directory : " directoryToCorrect
-   # This is apparently a problem with the next command after clear. --> directoryToCorrect=$(echo $directoryToCorrect | sed -r "s| |*|g")
-   clear
-   nameOfTestFile=$(ls -1 $directoryToCorrect | head -1)
-   
-   testDirCount=$(echo $nameOfTestFile | grep -o "/" | wc -w)
+	clear
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	echo "|--------------------------------------------------------------|"
+	echo "|                        ***WARNING***                         |"
+	echo "|       TV SHOW FILE NAMES MUST CONTAIN 'SXXEXX' X=number      |"
+	echo "|                                                              |"
+	echo "|            Please enter the directory to correct             |"
+	echo "|                        For example:                          |"
+	echo "|  /jfin/TV/*/*/* <- For every Episode(May Crash Be Careful!)  |"
+	echo "|                            OR:                               |"
+	echo "|  /jfin/TV/Breaking*Bad/*/* <- For Every Episode in a show    |"
+	echo "|                            OR:                               |"
+	echo "|  /jfin/TV/Breaking*Bad/Season*2/* <- For Every Episode in    |"
+	echo "|                    a season of a show                        |"
+	echo "|                                                              |"
+	echo "|      BE ADVISED, IF YOU'RE RE-NAMING MULTIPLE SHOWS,         |"
+	echo "|             MAKE SURE ALL THE SHOW DIRECTORY                 |"
+	echo "|      NAMES ARE IN THE SAME LOCATION IN THE DIRECTORY         |"
+	echo "|--------------------------------------------------------------|"
+	echo
+	read -p "Please enter a directory : " directoryToCorrect
+	# This is apparently a problem with the next command after clear. --> directoryToCorrect=$(echo $directoryToCorrect | sed -r "s| |*|g")
+	clear
+	nameOfTestFile=$(ls -1 $directoryToCorrect | head -1)
+	
+	testDirCount=$(echo $nameOfTestFile | grep -o "/" | wc -w)
 
-   if [[ $directoryToCorrect != *"/" ]]; then
-      testDirCount=$(($testDirCount + 1))
-   fi
+	if [[ $directoryToCorrect != *"/" ]]; then
+		testDirCount=$(($testDirCount + 1))
+	fi
 
-   iteration=2
-   number=1
+	iteration=2
+	number=1
 
-   while [ $number -lt $testDirCount ]; do
-      testName=$(echo $nameOfTestFile | cut -d "/" -f $iteration)
-      echo "$number : $testName"
-      iteration=$(($iteration + 1))
-      
-      number=$(($number + 1))   
-   done
-   
-   echo "Please enter the number that corresponds with the show's name above"
-   read directoryNumber
-   directoryNumber=$(($directoryNumber + 1))
-   nameOfShow=$(dirname "$directoryToCorrect" | cut -d "/" -f $directoryNumber)
-   echo "You chose $nameOfShow"
+	while [ $number -lt $testDirCount ]; do
+		testName=$(echo $nameOfTestFile | cut -d "/" -f $iteration)
+		echo "$number : $testName"
+		iteration=$(($iteration + 1))
+		
+		number=$(($number + 1))	
+	done
+	
+	echo "Please enter the number that corresponds with the show's name above"
+	read directoryNumber
+	directoryNumber=$(($directoryNumber + 1))
+	nameOfShow=$(dirname "$directoryToCorrect" | cut -d "/" -f $directoryNumber)
+	echo "You chose $nameOfShow"
 
-   for item in $directoryToCorrect
-   do
-      echo $item
-         if [[ "$item" == *[sS][0-9][0-9][eE][0-9][0-9]* ]]; then
-            extensionOfFile="${item##*.}"
-            nameOfDirectory=$(dirname "$item")
-            nameOfShow=$(dirname "$item" | cut -d "/" -f $directoryNumber)
-            episodeNumber=$(echo "$item" | grep -oE '[sS][0-9][0-9][eE][0-9][0-9]')
-            mv "$item" "$nameOfDirectory/$nameOfShow $episodeNumber.$extensionOfFile"
-            newItemName="$nameOfDirectory/$nameOfShow $episodeNumber.$extensionOfFile"
-            echo "item:"
-            echo "$item"
-            #echo "Directory:"
-            #echo "$nameOfDirectory"
-            #echo "Name Of Show:"
-            #echo $nameOfShow
-            #echo "Episode:"
-            #echo "$episodeNumber"
-            #echo "extension of file:"
-            #echo "$extensionOfFile"
-            echo "New Name:"
-            echo "$newItemName"
-            chown -fv $defaultUser:$defaultUser "$newItemName"
-            chmod -fv 770 "$newItemName"
-            echo
-         fi
-   done
+	for item in $directoryToCorrect
+	do
+		echo $item
+			if [[ "$item" == *[sS][0-9][0-9][eE][0-9][0-9]* ]]; then
+				extensionOfFile="${item##*.}"
+				nameOfDirectory=$(dirname "$item")
+				nameOfShow=$(dirname "$item" | cut -d "/" -f $directoryNumber)
+				episodeNumber=$(echo "$item" | grep -oE '[sS][0-9][0-9][eE][0-9][0-9]')
+				mv "$item" "$nameOfDirectory/$nameOfShow $episodeNumber.$extensionOfFile"
+				newItemName="$nameOfDirectory/$nameOfShow $episodeNumber.$extensionOfFile"
+				echo "item:"
+				echo "$item"
+				#echo "Directory:"
+				#echo "$nameOfDirectory"
+				#echo "Name Of Show:"
+				#echo $nameOfShow
+				#echo "Episode:"
+				#echo "$episodeNumber"
+				#echo "extension of file:"
+				#echo "$extensionOfFile"
+				echo "New Name:"
+				echo "$newItemName"
+				chown -fv $defaultUser:$defaultUser "$newItemName"
+				chmod -fv 770 "$newItemName"
+				echo
+			fi
+	done
 }
 
 Uninstall()
 {
-   Has_sudo
-   echo "|-------------------------------------------------------------------|"
-   echo "|                        ******WARNING******                        |"
-   echo "|                        ******CAUTION******                        |"
-   echo "|                     Are you completely sure?                      |"
-   echo "|          This will delete all files relating to Jellyfin          |"
-   echo "|   and Jellyman, exceptthe Media Library and jellyfin-backup.tar   |"
-   echo "|-------------------------------------------------------------------|"
-   echo
-   read -p "CONTINUE?: [yes/No]" toUninstallOrNotToUninstall
-   if [[ $toUninstallOrNotToUninstall == [yY][eE][sS] ]]; then
-      echo "Goodbye..."
-      sleep 1
-      source /opt/jellyfin/config/jellyman.conf
-         echo "Blocking port 8096 and 8920..."
-      if [ -x "$(command -v ufw)" ]; then
-         ufw deny 8096/tcp
-         ufw deny 8920/tcp
-         ufw reload
-      elif [ -x "$(command -v firewall-cmd)" ]; then
-         firewall-cmd --permanent --zone=public --remove-port=8096/tcp
-         firewall-cmd --permanent --zone=public --remove-port=8920/tcp
-         firewall-cmd --reload
-      else
-         echo "|-------------------------------------------------------------------|"
-         echo "|                        ******WARNING******                        |"
-         echo "|                        ******CAUTION******                        |"
-         echo "|                  FAILED TO CLOSE PORT 8096/8920!                  |"
-         echo "|          ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!          |"
-         echo "|-------------------------------------------------------------------|"
-      fi
-      rm -fv /etc/jellyfin.conf /bin/jellyman $jellyfinServiceLocation
-      rm -rfv /opt/jellyfin
-      userdel -f $defaultUser
-   else
-      echo "Phew! That was a close one!"
-   fi
+	Has_sudo
+	echo "|-------------------------------------------------------------------|"
+	echo "|                        ******WARNING******                        |"
+	echo "|                        ******CAUTION******                        |"
+	echo "|                     Are you completely sure?                      |"
+	echo "|          This will delete all files relating to Jellyfin          |"
+	echo "|   and Jellyman, exceptthe Media Library and jellyfin-backup.tar   |"
+	echo "|-------------------------------------------------------------------|"
+	echo
+	read -p "CONTINUE?: [yes/No]" toUninstallOrNotToUninstall
+	if [[ $toUninstallOrNotToUninstall == [yY][eE][sS] ]]; then
+		echo "Goodbye..."
+		sleep 1
+		source /opt/jellyfin/config/jellyman.conf
+			echo "Blocking port 8096 and 8920..."
+		if [ -x "$(command -v ufw)" ]; then
+			ufw deny 8096/tcp
+			ufw deny 8920/tcp
+			ufw reload
+		elif [ -x "$(command -v firewall-cmd)" ]; then
+			firewall-cmd --permanent --zone=public --remove-port=8096/tcp
+			firewall-cmd --permanent --zone=public --remove-port=8920/tcp
+			firewall-cmd --reload
+		else
+			echo "|-------------------------------------------------------------------|"
+			echo "|                        ******WARNING******                        |"
+			echo "|                        ******CAUTION******                        |"
+			echo "|                  FAILED TO CLOSE PORT 8096/8920!                  |"
+			echo "|          ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!          |"
+			echo "|-------------------------------------------------------------------|"
+		fi
+		rm -fv /etc/jellyfin.conf /bin/jellyman $jellyfinServiceLocation
+		rm -rfv /opt/jellyfin
+		userdel -f $defaultUser
+	else
+		echo "Phew! That was a close one!"
+	fi
 }
 
 
 isVideo()
 {
-   _video=$1
-   if [[ $_video == *"."[mMaA][kKvVpP][iIvV4] ]]; then
-      return 0
-   else
-      return 1
-   fi
+	_video=$1
+	if [[ $_video == *"."[mMaA][kKvVpP][iIvV4] ]]; then
+		return 0
+	else
+		return 1
+	fi
 }
 
 Transcode_file()
 {
-   videoToEdit="$1"
-   desiredGBperHour=$2
-   delteOrnot=$3
-   preset=$4
-   crf=$5
-   
-   videoSize=$(du -h "$videoToEdit" | cut -d "/" -f 1)
-   videoDuration=$(ffprobe -i "$videoToEdit" -show_entries format=duration -v quiet -of csv="p=0" | cut -d "." -f 1)
-   if isVideo "$videoToEdit"; then
-      _videoSizeGB=null
-      _videoTimeHours=$(bc -l <<< "$videoDuration/3600")
-      if [[ $videoSize == *"M"* ]]; then
-         _videoSizeMB=$(echo $videoSize | sed -r "s|M||g" | cut -d "	" -f 1)
-         _videoSizeGB=$(bc -l <<< "$_videoSizeMB/1024")
-      else
-         _videoSizeGB=$(echo $videoSize | sed -r "s|G||g")
-      fi
-      _videoRatio=$(bc -l <<< "$_videoSizeGB/$_videoTimeHours")
-      if [ 1 -eq "$(echo "$_videoRatio > $desiredGBperHour" | bc)" ]; then
-         #TRANSCODE FILE
-         echo "Transcoding $videoToEdit ..."
-         _newName=$(echo $videoToEdit | rev | cut -d "." -f 2 | rev)
-         echo "Video time in Hours: $_videoTimeHours"
-         echo "Video size GB:  $_videoSizeGB"
-         echo "Current GB/Hour: $_videoRatio"
-         time ffmpeg -i "$videoToEdit" -c:v libx265 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
-         _newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
-         echo "Downsampled size: $_newVideoSize"
-         if $deleteOrNot; then
-           echo "DELETING $videoToEdit IN 10 SECONDS!"
-           Countdown 10
-           rm -v "$videoToEdit"
-           mv -v "$_newName.downsampled.mp4" "$_newName.mp4"
-        fi
+	videoToEdit="$1"
+	desiredGBperHour=$2
+	delteOrnot=$3
+	preset=$4
+	crf=$5
+	
+	videoSize=$(du -h "$videoToEdit" | cut -d "/" -f 1)
+	videoDuration=$(ffprobe -i "$videoToEdit" -show_entries format=duration -v quiet -of csv="p=0" | cut -d "." -f 1)
+	if isVideo "$videoToEdit"; then
+		_videoSizeGB=null
+		_videoTimeHours=$(bc -l <<< "$videoDuration/3600")
+		if [[ $videoSize == *"M"* ]]; then
+			_videoSizeMB=$(echo $videoSize | sed -r "s|M||g" | cut -d "	" -f 1)
+			_videoSizeGB=$(bc -l <<< "$_videoSizeMB/1024")
+		else
+			_videoSizeGB=$(echo $videoSize | sed -r "s|G||g")
+		fi
+		_videoRatio=$(bc -l <<< "$_videoSizeGB/$_videoTimeHours")
+		if [ 1 -eq "$(echo "$_videoRatio > $desiredGBperHour" | bc)" ]; then
+			#TRANSCODE FILE
+			echo "Transcoding $videoToEdit ..."
+			_newName=$(echo $videoToEdit | rev | cut -d "." -f 2 | rev)
+			echo "Video time in Hours: $_videoTimeHours"
+			echo "Video size GB:  $_videoSizeGB"
+			echo "Current GB/Hour: $_videoRatio"
+			time ffmpeg -i "$videoToEdit" -c:v libx265 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
+			_newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
+			echo "Downsampled size: $_newVideoSize"
+			if $deleteOrNot; then
+			  echo "DELETING $videoToEdit IN 10 SECONDS!"
+			  Countdown 10
+			  rm -v "$videoToEdit"
+			  mv -v "$_newName.downsampled.mp4" "$_newName.mp4"
+		  fi
 
-      else
-         echo "$videoToEdit is less than $desiredGBperHour GB/Hour, skipping..."
-      fi
-   else
-      _file=$(echo $videoToEdit | rev | cut -d "/" -f 1 | rev)
-      echo "$_file is not a video, skipping..."
-   fi
+		else
+			echo "$videoToEdit is less than $desiredGBperHour GB/Hour, skipping..."
+		fi
+	else
+		_file=$(echo $videoToEdit | rev | cut -d "/" -f 1 | rev)
+		echo "$_file is not a video, skipping..."
+	fi
 }
 
 Transcode()
 {
-   echo "|--------------------------------------------------------------|"
-   echo "|                        ***WARNING***                         |"
-   echo "|          Please enter the directory to transcode             |"
-   echo "|                        For example:                          |"
-   echo "|  /jfin/TV/*/*/* <- For every Episode(May Crash Be Careful!)  |"
-   echo "|                            OR:                               |"
-   echo "|  /jfin/TV/Breaking*Bad/*/* <- For Every Episode in a show    |"
-   echo "|                            OR:                               |"
-   echo "|  /jfin/TV/Breaking*Bad/Season*2/* <- For Every Episode in    |"
-   echo "|                    a season of a show                        |"
-   echo "|                                                              |"
-   echo "|       BE ADVISED, IF YOU'RE TRANSCODING MULTIPLE FILES,      |"
-   echo "|       THIS IS GOING TO TAKE A WHILE, IT IS RECOMMENDED       |"
-   echo "|        TO RUN THIS COMMAND IN 'screen' THEN PRESSING         |"
-   echo "|                       CTRL + A THEN D                        |"
-   echo "|--------------------------------------------------------------|"
-   read -p 'Please enter the path to the file(s) : ' _directoryToCorrect
-   echo
-   echo "Please enter the desired GB per hour of video"
-   read -p "EXAMPLE: 1 OR 2.5 : " desiredGBperHour
-   
-   preset=0
-   while [ $preset -gt 9 ] || [ $preset -lt 1 ]; do
-     clear
-     echo
-     echo '* = recommended'
-     echo
-     echo "1: ultrafast"
-     echo "2: superfast"
-     echo "3: veryfast"
-     echo "4: faster"
-     echo "5: fast"
-     echo '6: medium *'
-     echo "7: slow"
-     echo "8: slower"
-     echo "9: veryslow"
-     echo
-     read -p "Please choose a transcode preset [1-9] : " preset
-     if [[ ! $preset == [1-9] ]]; then
-       preset=0
-     fi
-   done
-   echo
-   case "$preset" in
-      1)   preset="ultrafast" ;;
-      2)   preset="superfast" ;;
-      3)   preset="veryfast" ;;
-      4)   preset="faster" ;;
-      5)   preset="fast" ;;
-      6)   preset="medium" ;;
-      7)   preset="slow" ;;
-      8)   preset="slower" ;;
-      9)   preset="veryslow" ;;
-   esac
-   
-   crf=0
-   while [ $crf -gt 30 ] || [ $crf -lt 20 ]; do
-      clear
-      echo 'Please enter a Constant Rate Factor (CRF) [20-30]'
-      echo "22-26 is recommended"
-      read -p '20 is better quality and 30 is lower quality : ' crf
-      if [[ ! $crf == [0-9][0-9] ]]; then
-         crf=0
-      fi
-   done
-   echo
-   read -p 'Would you like to delete the original file(s) after transcode? [N/y] : ' deleteOrNot
-   echo
-   
-   if [[ $deleteOrNot == [yY]* ]]; then
-      deleteOrNot=true
-   else
-      deleteOrNot=false
-   fi
-   
-   for item in $_directoryToCorrect
-   do
-      Transcode_file "$item" $desiredGBperHour $deleteOrNot $preset $crf
-   done
+	echo "|--------------------------------------------------------------|"
+	echo "|                        ***WARNING***                         |"
+	echo "|          Please enter the directory to transcode             |"
+	echo "|                        For example:                          |"
+	echo "|  /jfin/TV/*/*/* <- For every Episode(May Crash Be Careful!)  |"
+	echo "|                            OR:                               |"
+	echo "|  /jfin/TV/Breaking*Bad/*/* <- For Every Episode in a show    |"
+	echo "|                            OR:                               |"
+	echo "|  /jfin/TV/Breaking*Bad/Season*2/* <- For Every Episode in    |"
+	echo "|                    a season of a show                        |"
+	echo "|                                                              |"
+	echo "|       BE ADVISED, IF YOU'RE TRANSCODING MULTIPLE FILES,      |"
+	echo "|       THIS IS GOING TO TAKE A WHILE, IT IS RECOMMENDED       |"
+	echo "|        TO RUN THIS COMMAND IN 'screen' THEN PRESSING         |"
+	echo "|                       CTRL + A THEN D                        |"
+	echo "|--------------------------------------------------------------|"
+	read -p 'Please enter the path to the file(s) : ' _directoryToCorrect
+	echo
+	echo "Please enter the desired GB per hour of video"
+	read -p "EXAMPLE: 1 OR 2.5 : " desiredGBperHour
+	
+	preset=0
+	while [ $preset -gt 9 ] || [ $preset -lt 1 ]; do
+	  clear
+	  echo
+	  echo '* = recommended'
+	  echo
+	  echo "1: ultrafast"
+	  echo "2: superfast"
+	  echo "3: veryfast"
+	  echo "4: faster"
+	  echo "5: fast"
+	  echo '6: medium *'
+	  echo "7: slow"
+	  echo "8: slower"
+	  echo "9: veryslow"
+	  echo
+	  read -p "Please choose a transcode preset [1-9] : " preset
+	  if [[ ! $preset == [1-9] ]]; then
+		 preset=0
+	  fi
+	done
+	echo
+	case "$preset" in
+		1)	preset="ultrafast" ;;
+		2)	preset="superfast" ;;
+		3)	preset="veryfast" ;;
+		4)	preset="faster" ;;
+		5)	preset="fast" ;;
+		6)	preset="medium" ;;
+		7)	preset="slow" ;;
+		8)	preset="slower" ;;
+		9)	preset="veryslow" ;;
+	esac
+	
+	crf=0
+	while [ $crf -gt 30 ] || [ $crf -lt 20 ]; do
+		clear
+		echo 'Please enter a Constant Rate Factor (CRF) [20-30]'
+		echo "22-26 is recommended"
+		read -p '20 is better quality and 30 is lower quality : ' crf
+		if [[ ! $crf == [0-9][0-9] ]]; then
+			crf=0
+		fi
+	done
+	echo
+	read -p 'Would you like to delete the original file(s) after transcode? [N/y] : ' deleteOrNot
+	echo
+	
+	if [[ $deleteOrNot == [yY]* ]]; then
+		deleteOrNot=true
+	else
+		deleteOrNot=false
+	fi
+	
+	for item in $_directoryToCorrect
+	do
+		Transcode_file "$item" $desiredGBperHour $deleteOrNot $preset $crf
+	done
 }
 
 Countdown()
@@ -858,48 +858,48 @@ Countdown()
 
 Update-jellyman()
 {
-   Has_sudo
-   wget -O /opt/jellyfin/config/jellyman_version https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1
-   currentJellymanVersion=$(cat /opt/jellyfin/config/jellyman_version | grep " - v" | cut -d "v" -f2)
-   rm -f /opt/jellyfin/config/jellyman_version
-   if [[ "v$currentJellymanVersion" == $jellymanVersion ]]; then
-      echo "Jellyman is up to date. No new versions available."
-      exit
-   else
-      echo "Updating Jellyman - The Jellyfin Manager from $jellymanVersion to v$currentJellymanVersion"
-      git clone https://github.com/Smiley-McSmiles/jellyman
-      cd jellyman
-      chmod ug+x setup.sh
-      sudo ./setup.sh -U
-   fi
+	Has_sudo
+	wget -O /opt/jellyfin/config/jellyman_version https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1
+	currentJellymanVersion=$(cat /opt/jellyfin/config/jellyman_version | grep " - v" | cut -d "v" -f2)
+	rm -f /opt/jellyfin/config/jellyman_version
+	if [[ "v$currentJellymanVersion" == $jellymanVersion ]]; then
+		echo "Jellyman is up to date. No new versions available."
+		exit
+	else
+		echo "Updating Jellyman - The Jellyfin Manager from $jellymanVersion to v$currentJellymanVersion"
+		git clone https://github.com/Smiley-McSmiles/jellyman
+		cd jellyman
+		chmod ug+x setup.sh
+		sudo ./setup.sh -U
+	fi
 }
 
 Change_Media_Directory()
 {
-   Has_sudo
-   echo "|---------------------------------------------------------|"
-   echo "| Please enter all media directories separated by a space |"
-   echo "|                       example:                          |"
-   echo "|          /media/hdd1/Movies /media/hdd2/TV              |"
-   echo "|---------------------------------------------------------|"
-   echo
-   read mediaPath
-   Change_variable defaultPath "$mediaPath" array
+	Has_sudo
+	echo "|---------------------------------------------------------|"
+	echo "| Please enter all media directories separated by a space |"
+	echo "|                       example:                          |"
+	echo "|          /media/hdd1/Movies /media/hdd2/TV              |"
+	echo "|---------------------------------------------------------|"
+	echo
+	read mediaPath
+	Change_variable defaultPath "$mediaPath" array
 }
 
 Has_sudo()
 {
-   has_sudo_access=""
-   `timeout -k .1 .1 bash -c "sudo /bin/chmod --help" >&/dev/null 2>&1` >/dev/null 2>&1
-   if [ $? -eq 0 ];then
-      has_sudo_access="YES"
-      source /opt/jellyfin/config/jellyman.conf
-   else
-      has_sudo_access="NO"
-      echo "$USER, you're not using sudo..."
-      echo "Please use 'sudo jellyman -[COMMAND] [PARAMETERS]'"
-      exit
-   fi
+	has_sudo_access=""
+	`timeout -k .1 .1 bash -c "sudo /bin/chmod --help" >&/dev/null 2>&1` >/dev/null 2>&1
+	if [ $? -eq 0 ];then
+		has_sudo_access="YES"
+		source /opt/jellyfin/config/jellyman.conf
+	else
+		has_sudo_access="NO"
+		echo "$USER, you're not using sudo..."
+		echo "Please use 'sudo jellyman -[COMMAND] [PARAMETERS]'"
+		exit
+	fi
 }
 
 ###############################################################################
@@ -911,58 +911,58 @@ Has_sudo()
 # MAIN                                                                        #
 ###############################################################################
 if [ -n "$1" ]; then
-   total=1
-   while [ -n "$1" ]; do
-      case "$1" in
-         -b) Backup $2
-             shift ;;
-         -d) systemctl disable jellyfin.service ;;
-         -e) systemctl enable jellyfin.service ;;
-         -h) Help ;;
-         -i) Import $2
-             shift ;;
-         -p) if [[ "$2" == "-"* ]]; then
-                Permissions 
-             else
-                Permissions $2
-                shift 
-             fi  ;;
-         -r) systemctl restart jellyfin.service ;;
-         -s) systemctl start jellyfin.service ;;
-         -S) systemctl stop jellyfin.service ;;
-         -t) Status ;;
-         -u) if [[ "$2" == "-"* ]]; then
-                Update
-             else
-                Update $2
-                shift
-             fi ;;
-         -U) Update-jellyman 
-             exit ;;
-         -ub) Update_beta ;;
-         -v) Get_jellyfin_version
-             Get_jellyman_version ;;
-         -vd) Download_version ;;
-         -vs) Version_switch ;;
-         -rv) Remove_version ;;
-         -rc) Recertify_https ;;
-         -rn) Rename_tv ;;
-         -ls) Library_scan ;;
-         -cp) Http_port_change ;;
-         -cps) Https_port_change ;;
-         -ik) Import_api_key ;;
-         -md) Change_Media_Directory ;;
-         -tc) Transcode ;;
-         -X) Uninstall ;;
-         *) echo "Option $1 not recognized" 
-            Help ;;
-      esac
-      shift
-   done
+	total=1
+	while [ -n "$1" ]; do
+		case "$1" in
+			-b) Backup $2
+				 shift ;;
+			-d) systemctl disable jellyfin.service ;;
+			-e) systemctl enable jellyfin.service ;;
+			-h) Help ;;
+			-i) Import $2
+				 shift ;;
+			-p) if [[ "$2" == "-"* ]]; then
+					 Permissions 
+				 else
+					 Permissions $2
+					 shift 
+				 fi  ;;
+			-r) systemctl restart jellyfin.service ;;
+			-s) systemctl start jellyfin.service ;;
+			-S) systemctl stop jellyfin.service ;;
+			-t) Status ;;
+			-u) if [[ "$2" == "-"* ]]; then
+					 Update
+				 else
+					 Update $2
+					 shift
+				 fi ;;
+			-U) Update-jellyman 
+				 exit ;;
+			-ub) Update_beta ;;
+			-v) Get_jellyfin_version
+				 Get_jellyman_version ;;
+			-vd) Download_version ;;
+			-vs) Version_switch ;;
+			-rv) Remove_version ;;
+			-rc) Recertify_https ;;
+			-rn) Rename_tv ;;
+			-ls) Library_scan ;;
+			-cp) Http_port_change ;;
+			-cps) Https_port_change ;;
+			-ik) Import_api_key ;;
+			-md) Change_Media_Directory ;;
+			-tc) Transcode ;;
+			-X) Uninstall ;;
+			*) echo "Option $1 not recognized" 
+				Help ;;
+		esac
+		shift
+	done
 else
-   echo "No commands found."
-   Help
-   exit
+	echo "No commands found."
+	Help
+	exit
 fi
 
 ###############################################################################

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -808,7 +808,7 @@ Transcode()
      fi
    done
    echo
-   case "$cpuArchitectureFull" in
+   case "$preset" in
       1)   preset="ultrafast" ;;
       2)   preset="superfast" ;;
       3)   preset="veryfast" ;;

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -117,6 +117,13 @@ Get_jellyman_version()
 	echo "Jellyman $jellymanVersion"
 }
 
+Get_jellyfin_version()
+{
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	echo $currentVersion
+}
+
 Download_version()
 {
 	Has_sudo
@@ -162,7 +169,7 @@ Version_switch()
 	Has_sudo
 	versionToSwitchNumber=0
 	installedVersions=$(ls /opt/jellyfin/ | grep "_")
-	maxNumber=$(echo $installedVersions | wc -l)
+	maxNumber=$(echo "$installedVersions" | wc -l)
 	warning=
 
 	while [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; do
@@ -175,7 +182,7 @@ Version_switch()
 		echo $warning
 		echo "Please enter the number corresponding with"
 		read -p "the version you want to install : " versionToSwitchNumber
-		newVersion=$(echo $installedVersions | head -n $versionToSwitchNumber | tail -n 1)
+		newVersion=$(echo "$installedVersions" | head -n $versionToSwitchNumber | tail -n 1)
 
 		if [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; then
 			warning="ERROR: Please select one of the numbers provided!"
@@ -194,14 +201,15 @@ Version_switch()
 Remove_version()
 {
 	Has_sudo
-	versionToSwitchNumber=0
+	versionToRemoveNumber=0
 	versionToRemove=""
 	installedVersions=$(ls /opt/jellyfin/ | grep "_")
-	maxNumber=$(echo $installedVersions | wc -l)
+	maxNumber=$(echo "$installedVersions" | wc -l)
 	warning=
 
-	while [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; do
+	while [[ ! $versionToRemoveNumber == [1-$maxNumber] ]]; do
 		clear
+		echo $maxNumber
 		echo "Current Jellyfin version installed"
 		echo "$currentVersion"
 		echo
@@ -211,16 +219,18 @@ Remove_version()
 		echo "$warning"
 		echo "Please enter the number corresponding with"
 		read -p "the version you want to ERASE : " versionToRemoveNumber
-		versionToRemove=$(ehco $installedVersions | head -n $versionToRemoveNumber | tail -n 1)
+		versionToRemove=$(echo "$installedVersions" | head -n $versionToRemoveNumber | tail -n 1)
 		warning="ERROR: Please select one of the numbers provided!"
 		if isCurrentVersion $versionToRemove; then
-			warning="ERROR: v$versionToRemove is the currently running version.
+			warning="ERROR: $versionToRemove is the currently running version.
 Please use 'jellyman -vs' and choose a different version,
-before removing v$versionToRemove"
+before removing $versionToRemove"
 			versionToRemoveNumber=0
 		fi
 	done
 
+		echo "Removing /opt/jellyfin/$versionToRemove"
+		Countdown 5
 		rm -rfv /opt/jellyfin/$versionToRemove
 }
 
@@ -722,7 +732,8 @@ Uninstall()
 	read -p "CONTINUE?: [yes/No]" toUninstallOrNotToUninstall
 	if [[ $toUninstallOrNotToUninstall == [yY][eE][sS] ]]; then
 		echo "Goodbye..."
-		sleep 1
+		echo "Removing Jellyfin and Jellyman in:"
+		Countdown 5
 		source /opt/jellyfin/config/jellyman.conf
 			echo "Blocking port 8096 and 8920..."
 		if [ -x "$(command -v ufw)" ]; then
@@ -1017,8 +1028,8 @@ if [ -n "$1" ]; then
 			-U) Update-jellyman 
 				 exit ;;
 			-ub) Update_beta ;;
-			-v) echo "$currentVersion"
-				 Get_jellyman_version ;;
+			-v) Get_jellyfin_version
+					Get_jellyman_version ;;
 			-vd) Download_version ;;
 			-vs) Version_switch ;;
 			-rv) Remove_version ;;

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -722,6 +722,9 @@ Transcode_file()
    videoToEdit="$1"
    desiredGBperHour=$2
    delteOrnot=$3
+   preset=$4
+   crf=$5
+   
    videoSize=$(du -h "$videoToEdit" | cut -d "/" -f 1)
    videoDuration=$(ffprobe -i "$videoToEdit" -show_entries format=duration -v quiet -of csv="p=0" | cut -d "." -f 1)
    if isVideo "$videoToEdit"; then
@@ -741,7 +744,7 @@ Transcode_file()
          echo "Video time in Hours: $_videoTimeHours"
          echo "Video size GB:  $_videoSizeGB"
          echo "Current GB/Hour: $_videoRatio"
-         time ffmpeg -i "$videoToEdit" -c:v libx265 -c:a copy -movflags +faststart -preset medium -crf 24 "$_newName.downsampled.mp4"
+         time ffmpeg -i "$videoToEdit" -c:v libx265 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
          _newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
          echo "Downsampled size: $_newVideoSize"
          if $deleteOrNot; then
@@ -781,7 +784,52 @@ Transcode()
    read -p 'Please enter the path to the file(s) : ' _directoryToCorrect
    echo
    echo "Please enter the desired GB per hour of video"
-   read -p "EXAMPLE: 1 OR 2.5 : " _desiredGBperHour
+   read -p "EXAMPLE: 1 OR 2.5 : " desiredGBperHour
+   
+   preset=0
+   while [ $preset -gt 9 ] || [ $preset -lt 1 ]; do
+     clear
+     echo
+     echo '* = recommended'
+     echo
+     echo "1: ultrafast"
+     echo "2: superfast"
+     echo "3: veryfast"
+     echo "4: faster"
+     echo "5: fast"
+     echo '6: medium *'
+     echo "7: slow"
+     echo "8: slower"
+     echo "9: veryslow"
+     echo
+     read -p "Please choose a transcode preset [1-9] : " preset
+     if [[ ! $preset == [1-9] ]]; then
+       preset=0
+     fi
+   done
+   echo
+   case "$cpuArchitectureFull" in
+      1)   preset="ultrafast" ;;
+      2)   preset="superfast" ;;
+      3)   preset="veryfast" ;;
+      4)   preset="faster" ;;
+      5)   preset="fast" ;;
+      6)   preset="medium" ;;
+      7)   preset="slow" ;;
+      8)   preset="slower" ;;
+      9)   preset="veryslow" ;;
+   esac
+   
+   crf=0
+   while [ $crf -gt 30 ] || [ $crf -lt 20 ]; do
+      clear
+      echo 'Please enter a Constant Rate Factor (CRF) [20-30]'
+      echo "22-26 is recommended"
+      read -p '20 is better quality and 30 is lower quality : ' crf
+      if [[ ! $crf == [0-9][0-9] ]]; then
+         crf=0
+      fi
+   done
    echo
    read -p 'Would you like to delete the original file(s) after transcode? [N/y] : ' deleteOrNot
    echo
@@ -794,7 +842,7 @@ Transcode()
    
    for item in $_directoryToCorrect
    do
-      Transcode_file "$item" $_desiredGBperHour $deleteOrNot
+      Transcode_file "$item" $desiredGBperHour $deleteOrNot $preset $crf
    done
 }
 

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -145,7 +145,7 @@ Download_version()
 			versionToSwitchnumber=0
 			warning="ERROR: Please select one of the numbers provided!"
 			echo "Press CTRL+C to exit..."
-		elif isCurrentVersion jellyfin_$newVersionNumber || isInstalledVersion jellyfin_$newVersionNumber; then
+		elif isCurrentVersion "jellyfin_$newVersionNumber" || isInstalledVersion "jellyfin_$newVersionNumber"; then
 			versionToSwitchnumber=0
 			warning="ERROR: That Jellyfin version is already installed!"
 			echo "Press CTRL+C to exit..."

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -81,9 +81,8 @@ isCurrentVersion()
 isInstalledVersion()
 {
 	jellyfinVersionToDownload=$1
-	currentJellyfinVersions=$(ls /opt/jellyfin/ | grep "jellyfin_")
 	
-	if [[ $currentJellyfinVersions == *"$jellyfinVersionToDownload"* ]]; then
+	if [ -d /opt/jellyfin/$jellyfinVersionToDownload ]; then
 		echo "The version to download matches an already installed version."
 		echo "Please use 'jellyman -vs' to switch Jellyfin versions."
 		return 0
@@ -113,13 +112,6 @@ Check_disk_free()
 	fi
 }
 
-Get_jellyfin_version()
-{
-	Has_sudo
-	source /opt/jellyfin/config/jellyman.conf
-	echo "$currentVersion"
-}
-
 Get_jellyman_version()
 {
 	echo "Jellyman $jellymanVersion"
@@ -130,7 +122,8 @@ Download_version()
 	Has_sudo
 	source /opt/jellyfin/config/jellyman.conf
 	versionListVar=$(curl -sL https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/)
-	versionList=$(echo "$versionListVar" | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n)
+	versionList=$(echo "$versionListVar" | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g")
+	versionListNumbered=$(echo "$versionList" | cat -n)
 	maxNumber=$(echo "$versionList" | wc -l)
 	newVersionNumber=""
 	versionToSwitchNumber=0
@@ -138,9 +131,12 @@ Download_version()
 
 	while (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); do
 		clear
+		echo "Current Jellyfin version installed"
+		echo "$currentVersion"
+		echo
 		echo "Please select a stable version:"
 		echo $warning
-		echo "$versionList"
+		echo "$versionListNumbered"
 		echo "Please enter the number corresponding with"
 		read -p "the version you want to install [1-$maxNumber] : " versionToSwitchNumber
 		newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1)
@@ -172,7 +168,7 @@ Version_switch()
 	while [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; do
 		clear
 		echo "Current Jellyfin version installed"
-		Get_version
+		echo "$currentVersion"
 		echo
 		echo "Jellyfin versions already downloaded:"
 		echo "$installedVersions" | cat -n
@@ -207,7 +203,7 @@ Remove_version()
 	while [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; do
 		clear
 		echo "Current Jellyfin version installed"
-		Get_version
+		echo "$currentVersion"
 		echo
 		echo "Jellyfin versions already downloaded:"
 		echo "$installedVersions" | cat -n
@@ -1021,7 +1017,7 @@ if [ -n "$1" ]; then
 			-U) Update-jellyman 
 				 exit ;;
 			-ub) Update_beta ;;
-			-v) Get_jellyfin_version
+			-v) echo "$currentVersion"
 				 Get_jellyman_version ;;
 			-vd) Download_version ;;
 			-vs) Version_switch ;;

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.6.3"
+jellymanVersion="v1.6.4"
 
 ###############################################################################
 # FUNCTIONS                                                                   #
@@ -741,7 +741,7 @@ Transcode_file()
          echo "_videoTimeHours = $_videoTimeHours"
          echo "_videoSizeGB = $_videoSizeGB"
          echo "_videoRatio = $_videoRatio"
-         ffmpeg -i "$videoToEdit" -c:v libx265 -c:a copy -movflags +faststart -preset medium -crf 24 "$_newName.downsampled.mp4"
+         time ffmpeg -i "$videoToEdit" -c:v libx265 -c:a copy -movflags +faststart -preset medium -crf 24 "$_newName.downsampled.mp4"
          if $deleteOrNot; then
            echo "DELETING $videoToEdit IN 10 SECONDS!"
            Countdown 10

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -128,23 +128,34 @@ Download_version()
 {
 	Has_sudo
 	source /opt/jellyfin/config/jellyman.conf
-	mkdir /opt/jellyfin/update
-	versionList=$(curl -sL https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/)
-	clear
-	echo $versionList | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n
-	echo
-	echo "Please enter the number corresponding with"
-	read -p "the version you want to install : " versionToSwitchNumber
-	newVersion=$(echo $versionList | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | head -n $versionToSwitchNumber | tail -n 1)
-	maxNumber=$(echo $versionList | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | wc -l)
-	 if [[ $versionToSwitchNumber == *['!'@#\$%^\&*()_+.]* ]] || [[ $versionToSwitchNumber =~ [a-zA-Z]+$ ]] || (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); then
-		echo "The new version you chose doesn't exist, please run this command again and pick a LISTED NUMBER"
-	  exit
-	else
-		newVersionUnderscore=$(echo "$newVersion"_)
-		echo "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
-		jellyman -u "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersion/jellyfin_$newVersionUnderscore$architecture.tar.gz"
-	fi
+	versionListVar=$(curl -sL https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/)
+	versionList=$(echo "$versionListVar" | grep -o ">[0-9][0-9].[0-9].[0-9]" | sed -r "s|>||g" | cat -n)
+	maxNumber=$(echo "$versionList" | wc -l)
+	newVersionNumber=""
+	versionToSwitchNumber=0
+	warning=""
+
+	while (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); do
+		clear
+		echo "Please select a stable version:"
+		echo $warning
+		echo "$versionList"
+		echo "Please enter the number corresponding with"
+		read -p "the version you want to install [1-$maxNumber] : " versionToSwitchNumber
+		newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1)
+
+		if [[ ! $versionToSwitchNumber == [1-$maxNumber] ]]; then
+			versionToSwitchnumber=0
+			warning="Please select one of the numbers provided!"
+		elif isCurrentVersion jellyfin_$newVersionNumber || isInstalledVersion jellyfin_$newVersionNumber; then
+			versionToSwitchnumber=0
+			warning="That Jellyfin version is already installed!"
+		else
+			newVersionUnderscore=$(echo "$newVersionNumber"_)
+			echo "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersionNumber/jellyfin_$newVersionUnderscore$architecture.tar.gz"
+			jellyman -u "https://repo.jellyfin.org/releases/server/linux/versions/stable/combined/$newVersionNumber/jellyfin_$newVersionUnderscore$architecture.tar.gz"
+		fi
+	done
 }
 
 Version_switch()
@@ -500,45 +511,59 @@ Update()
 }
 
 
+# needs testing when new beta is available
 Update_beta()
 {
 	Has_sudo
 	source /opt/jellyfin/config/jellyman.conf
-	jellyfin_archive=""
-	jellyfin=""
-	new_jellyfin_version=""
+	betasAvailable=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable-pre/)
+	jellyfinArchives=$(echo "$betasAvailable" | grep "combined" | grep -o jellyfin_.*_$architecture.tar.gz'"' | cut -d '"' -f 1)
+	jellyfinNumbered=$(echo "$jellyfinArchives" | sed -r "s|_$architecture.tar.gz||g" | cat -n)
+	versionSelected=0
+	maxNumber=$(echo "$jellyfinNumbered" | wc -l)
+	newVersionName=
+	newVersionNumber=
+	newVersionArchive=
+	warning=""
 	
-	echo "Fetching newest beta Jellyfin version..."
-	mkdir /opt/jellyfin/update
-	betasAvailable=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable-pre/) # needs testing when new beta is available
-	jellyfin_archive=$(echo $betasAvailable | grep "$architecture.tar.gz" | grep 'combined' | cut -d '/' -f5 | cut -d '<' -f1 | head -n 1 | sed -r "s|.sha256sum||g")
-	jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-	new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
-	if [[ ! -n $jellyfin_archive ]] || [[ ! -n $jellyfin ]]; then
-		echo "Sorry there appears to be no Jellyfin Betas right now..."
+	if [[ ! $betasAvailable == .*"tar.gz".* ]]; then
+		echo "Sorry, no pre-releases are available right now..."
 		exit
-	else
-		if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
-			wget -O /opt/jellyfin/update/$jellyfin_archive https://repo.jellyfin.org/releases/server/linux/stable-pre/$new_jellyfin_version/combined/$jellyfin_archive
-		else
-			exit
-		fi
-
-
-		echo "Unpacking $jellyfin_archive to /opt/jellyfin/..."
-		tar xvzf /opt/jellyfin/update/$jellyfin_archive -C /opt/jellyfin/
-		jellyman -S
-		unlink /opt/jellyfin/jellyfin
-		ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
-		echo "Removing $jellyfin_archive"
-		rm -rfv /opt/jellyfin/update
-
-		chown -R $defaultUser:$defaultUser /opt/jellyfin
-		echo "Jellyfin updated to version $new_jellyfin_version"
-		Change_variable currentVersion $jellyfin
-		jellyman -s -t
 	fi
+
+	while (( $versionSelected > $maxNumber )) || (( $versionSelected < 1 )); do
+		clear
+		echo "Available pre-releases:"
+		echo $warning
+		echo "$jellyfinNumbered"
+		read -p "Select which version to install [1-$maxNumber] : " versionSelected
+		newVersionName=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1 | sed -r "s|_$architecture.tar.gz||g")
+		newVersionNumber=$(echo $newVersionName | sed -r 's/jellyfin_//g')
+		if [[ ! $versionSelected == [1-$maxNumber] ]]; then
+			versionSelected=0
+			warning="ERROR: Please select one of the numbers provided!"
+		elif isCurrentVersion $newVersionName || isInstalledVersion $newVersionName; then
+			warning="ERROR: That Jellyfin version is already installed!"
+		else
+			newVersionArchive=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1)
+			echo "Getting $newVersionArchive..."
+			wget -O /opt/jellyfin/update/$newVersionName https://repo.jellyfin.org/releases/server/linux/stable-pre/$newVersionNumber/combined/$newVersionArchive
+			echo "Unpacking $newVersionArchive to /opt/jellyfin/..."
+			tar xvzf /opt/jellyfin/update/$newVersionArchive -C /opt/jellyfin/
+			jellyman -S
+			unlink /opt/jellyfin/jellyfin
+			ln -s /opt/jellyfin/$newVersionName /opt/jellyfin/jellyfin
+			echo "Removing $newVersionArchive"
+			rm -rfv /opt/jellyfin/update
+
+			chown -R $defaultUser:$defaultUser /opt/jellyfin
+			echo "Jellyfin updated to version $newVersionNumber"
+			Change_variable currentVersion $newVersionName
+			jellyman -s -t
+		fi
+	done
 }
+
 
 Is_jellyfin_setup()
 {

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -738,10 +738,12 @@ Transcode_file()
          #TRANSCODE FILE
          echo "Transcoding $videoToEdit ..."
          _newName=$(echo $videoToEdit | rev | cut -d "." -f 2 | rev)
-         echo "_videoTimeHours = $_videoTimeHours"
-         echo "_videoSizeGB = $_videoSizeGB"
-         echo "_videoRatio = $_videoRatio"
+         echo "Video time in Hours: $_videoTimeHours"
+         echo "Video size GB:  $_videoSizeGB"
+         echo "Current GB/Hour: $_videoRatio"
          time ffmpeg -i "$videoToEdit" -c:v libx265 -c:a copy -movflags +faststart -preset medium -crf 24 "$_newName.downsampled.mp4"
+         _newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
+         echo "Downsampled size: $_newVideoSize"
          if $deleteOrNot; then
            echo "DELETING $videoToEdit IN 10 SECONDS!"
            Countdown 10

--- a/setup.sh
+++ b/setup.sh
@@ -8,456 +8,456 @@ tarPath=
 
 Has_sudo()
 {
-   has_sudo_access=""
-   `timeout -k .1 .1 bash -c "sudo /bin/chmod --help" >&/dev/null 2>&1` >/dev/null 2>&1
-   if [ $? -eq 0 ];then
-      has_sudo_access="YES"
-   else
-      has_sudo_access="NO"
-      echo "$USER, you're not using sudo..."
-      echo "Please use 'sudo ./setup.sh' to install the scripts."
-      exit
-   fi
+	has_sudo_access=""
+	`timeout -k .1 .1 bash -c "sudo /bin/chmod --help" >&/dev/null 2>&1` >/dev/null 2>&1
+	if [ $? -eq 0 ];then
+		has_sudo_access="YES"
+	else
+		has_sudo_access="NO"
+		echo "$USER, you're not using sudo..."
+		echo "Please use 'sudo ./setup.sh' to install the scripts."
+		exit
+	fi
 }
 
 Import()
 {
-   Has_sudo
-   importTar=$1
-   echo "|-------------------------------------------------------------------|"
-   echo "|                        ******WARNING******                        |"
-   echo "|                        ******CAUTION******                        |"
-   echo "|This procedure should only be used as a fresh install of Jellyfin. |"
-   echo "|       As this procedure will erase /opt/jellyfin COMPLETELY       |"
-   echo "|-------------------------------------------------------------------|"
+	Has_sudo
+	importTar=$1
+	echo "|-------------------------------------------------------------------|"
+	echo "|                        ******WARNING******                        |"
+	echo "|                        ******CAUTION******                        |"
+	echo "|This procedure should only be used as a fresh install of Jellyfin. |"
+	echo "|       As this procedure will erase /opt/jellyfin COMPLETELY       |"
+	echo "|-------------------------------------------------------------------|"
 
-   read -p "...Continue? [yes/No] :" importOrNotToImport
-   if [[ $importOrNotToImport == [yY][eE][sS] ]]; then
-      echo "IMPORTING $importTar"
-      jellyman -S
-      rm -rf /opt/jellyfin
-      tar xvf $importTar -C /
-      clear
-      source /opt/jellyfin/config/jellyman.conf
-      mv -f /opt/jellyfin/backup/jellyman /bin/
-      chmod +x /bin/jellyman
-      
-      if [ -d /usr/lib/systemd/system ]; then
-         mv -f /opt/jellyfin/backup/jellyfin.service /usr/lib/systemd/system/
-      else
-         mv -f /opt/jellyfin/backup/jellyfin.service /etc/systemd/system
-      fi
-      
-      mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
-      if id "$defaultUser" &>/dev/null; then 
-         chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-         chmod -Rfv 770 /opt/jellyfin
-         Install_dependancies
-         jellyman -e -s -t
-      else
-         clear
-         echo "|-----------------------------------------------------------------------------------------------|"
-         echo "|                                     ******WARNING******                                       |"
-         echo "|                                     *******ERROR*******                                       |"
-         echo "|             The imported default Jellyfin user($defaultUser) has not yet been created.        |"
-         echo "|   This error is likely due to a read error of the /opt/jellyfin/config/jellyman.conf file.    |"
-         echo "| The default user is usually created by Jellyman - The Jellyfin Manager, when running setup.sh.|"
-         echo "|                 You may want to see who owns that configuration file with:                    |"
-         echo "|                         'ls -l /opt/jellyfin/config/jellyman.conf'                            |"
-         echo "|-----------------------------------------------------------------------------------------------|"
-         sleep 5
-         read -p "...Continue with $defaultUser? [yes/No] :" newUserOrOld
-         if [[ $newUserOrOld == [yY][eE][sS] ]]; then
-            echo "Great!"
-            sleep .5
-            chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-            chmod -Rfv 770 /opt/jellyfin
-            Install_dependancies
-            jellyman -s -t
-         else
-            read -p "No? Which user should own /opt/jellyfin?: " defaultUser
-            echo "Well... I should've known $defaultUser would be the one..."
-            sleep 1
-            read -p "Please enter the default user for Jellyfin: " defaultUser
-      while id "$defaultUser" &>/dev/null; do
-           echo "Cannot create $defaultUser as $defaultUser already exists..."
-           read -p "Please re-enter a new default user for Jellyfin: " defaultUser
-       done
-       
-            useradd -rd /opt/jellyfin $defaultUser
-            
-            chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-            chmod -Rfv 770 /opt/jellyfin
-            Install_dependancies
-            jellyman -e -s -t
-         fi
-      fi
+	read -p "...Continue? [yes/No] :" importOrNotToImport
+	if [[ $importOrNotToImport == [yY][eE][sS] ]]; then
+		echo "IMPORTING $importTar"
+		jellyman -S
+		rm -rf /opt/jellyfin
+		tar xvf $importTar -C /
+		clear
+		source /opt/jellyfin/config/jellyman.conf
+		mv -f /opt/jellyfin/backup/jellyman /bin/
+		chmod +x /bin/jellyman
+		
+		if [ -d /usr/lib/systemd/system ]; then
+			mv -f /opt/jellyfin/backup/jellyfin.service /usr/lib/systemd/system/
+		else
+			mv -f /opt/jellyfin/backup/jellyfin.service /etc/systemd/system
+		fi
+		
+		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
+		if id "$defaultUser" &>/dev/null; then 
+			chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
+			chmod -Rfv 770 /opt/jellyfin
+			Install_dependancies
+			jellyman -e -s -t
+		else
+			clear
+			echo "|-----------------------------------------------------------------------------------------------|"
+			echo "|                                     ******WARNING******                                       |"
+			echo "|                                     *******ERROR*******                                       |"
+			echo "|          The imported default Jellyfin user($defaultUser) has not yet been created.           |"
+			echo "|    This error is likely due to a read error of the /opt/jellyfin/config/jellyman.conf file.   |"
+			echo "| The default user is usually created by Jellyman - The Jellyfin Manager, when running setup.sh.|"
+			echo "|                   You may want to see who owns that configuration file with:                  |"
+			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
+			echo "|-----------------------------------------------------------------------------------------------|"
+			sleep 5
+			read -p "...Continue with $defaultUser? [yes/No] :" newUserOrOld
+			if [[ $newUserOrOld == [yY][eE][sS] ]]; then
+				echo "Great!"
+				sleep .5
+				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rfv 770 /opt/jellyfin
+				Install_dependancies
+				jellyman -s -t
+			else
+				read -p "No? Which user should own /opt/jellyfin?: " defaultUser
+				echo "Well... I should've known $defaultUser would be the one..."
+				sleep 1
+				read -p "Please enter the default user for Jellyfin: " defaultUser
+		while id "$defaultUser" &>/dev/null; do
+			  echo "Cannot create $defaultUser as $defaultUser already exists..."
+			  read -p "Please re-enter a new default user for Jellyfin: " defaultUser
+		 done
+		 
+				useradd -rd /opt/jellyfin $defaultUser
+				
+				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rfv 770 /opt/jellyfin
+				Install_dependancies
+				jellyman -e -s -t
+			fi
+		fi
 
-   else
-      echo "Returning..."
-   fi    
+	else
+		echo "Returning..."
+	fi	 
 }
 
 Get_Architecture()
 {
-   cpuArchitectureFull=$(uname -m)
-      case "$cpuArchitectureFull" in
-            x86_64)   architecture="amd64" ;;
-            aarch64)  architecture="arm64" ;;
-            armv*)    architecture="armhf" ;;
-            *)        echo "ERROR UNKNOWN CPU ARCHITECTURE.. EXITING."
-                      exit ;;
-      esac
+	cpuArchitectureFull=$(uname -m)
+		case "$cpuArchitectureFull" in
+				x86_64)	architecture="amd64" ;;
+				aarch64)  architecture="arm64" ;;
+				armv*)	 architecture="armhf" ;;
+				*)		  echo "ERROR UNKNOWN CPU ARCHITECTURE.. EXITING."
+							 exit ;;
+		esac
 }
 
 Install_dependancies()
 {
-   packagesNeededDebian='ffmpeg git net-tools openssl'
-   packagesNeededRHEL='ffmpeg ffmpeg-devel ffmpeg-libs git openssl'
-   packagesNeededArch='ffmpeg git openssl'
-   packagesNeededOpenSuse='ffmpeg-4 git openssl'
-   echo "Preparing to install needed dependancies for Jellyfin..."
+	packagesNeededDebian='ffmpeg git net-tools openssl'
+	packagesNeededRHEL='ffmpeg ffmpeg-devel ffmpeg-libs git openssl'
+	packagesNeededArch='ffmpeg git openssl'
+	packagesNeededOpenSuse='ffmpeg-4 git openssl'
+	echo "Preparing to install needed dependancies for Jellyfin..."
 
-   if [ -f /etc/os-release ]; then
-      source /etc/os-release
-      crbOrPowertools=
-      os_detected=true
-      echo "ID=$ID"
-      
-      if [[ $ID_LIKE == *"rhel"* ]] || [[ $ID == "rhel" ]]; then
-         ID=rhel
-         
-         if [[ $VERSION_ID == *"."* ]]; then
-            VERSION_ID=$(echo $VERSION_ID | cut -d "." -f 1)
-         fi
-         
-         if (( $VERSION_ID < 9 )); then
-            crbOrPowertools="powertools"
-         else
-            crbOrPowertools="crb"
-         fi
-      fi
-      
-         case "$ID" in
-            fedora)     dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y
-                        dnf install $packagesNeededRHEL -y ;;
-            rhel)       dnf install epel-release -y
-                        dnf config-manager --set-enabled $crbOrPowertools
-                        dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm -y https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm -y
-                        dnf install $packagesNeededRHEL -y ;;
-            debian)     apt install $packagesNeededDebian -y ;;
-            ubuntu)     apt install $packagesNeededDebian -y ;;
-            linuxmint)  apt install $packagesNeededDebian -y ;;
-            elementary) apt install $packagesNeededDebian -y ;;
-            arch)       pacman -Syu $packagesNeededArch  ;;
-            endeavouros) pacman -Syu $packagesNeededArch  ;;
-            manjaro)    pacman -Syu $packagesNeededArch  ;;
-            opensuse*)  zypper install $packagesNeededOpenSuse ;;
-         esac
-   else
-      os_detected=false
-      echo "|-------------------------------------------------------------------|"
-      echo "|                        ******WARNING******                        |"
-      echo "|                         ******ERROR******                         |"
-      echo "|                  FAILED TO FIND /etc/os-release FILE.             |"
-      echo "|                PLEASE MANUALLY INSTALL THESE PACKAGES:            |"
-      echo "|                       ffmpeg git AND openssl                      |"
-      echo "|-------------------------------------------------------------------|"
-      
-      read -p "Press ENTER to continue" ENTER
-   fi
+	if [ -f /etc/os-release ]; then
+		source /etc/os-release
+		crbOrPowertools=
+		os_detected=true
+		echo "ID=$ID"
+		
+		if [[ $ID_LIKE == *"rhel"* ]] || [[ $ID == "rhel" ]]; then
+			ID=rhel
+			
+			if [[ $VERSION_ID == *"."* ]]; then
+				VERSION_ID=$(echo $VERSION_ID | cut -d "." -f 1)
+			fi
+			
+			if (( $VERSION_ID < 9 )); then
+				crbOrPowertools="powertools"
+			else
+				crbOrPowertools="crb"
+			fi
+		fi
+		
+			case "$ID" in
+				fedora)	  dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y
+								dnf install $packagesNeededRHEL -y ;;
+				rhel)		 dnf install epel-release -y
+								dnf config-manager --set-enabled $crbOrPowertools
+								dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm -y https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm -y
+								dnf install $packagesNeededRHEL -y ;;
+				debian)	  apt install $packagesNeededDebian -y ;;
+				ubuntu)	  apt install $packagesNeededDebian -y ;;
+				linuxmint)  apt install $packagesNeededDebian -y ;;
+				elementary) apt install $packagesNeededDebian -y ;;
+				arch)		 pacman -Syu $packagesNeededArch  ;;
+				endeavouros) pacman -Syu $packagesNeededArch  ;;
+				manjaro)	 pacman -Syu $packagesNeededArch  ;;
+				opensuse*)  zypper install $packagesNeededOpenSuse ;;
+			esac
+	else
+		os_detected=false
+		echo "|-------------------------------------------------------------------|"
+		echo "|                       ******WARNING******                         |"
+		echo "|                        ******ERROR******                          |"
+		echo "|               FAILED TO FIND /etc/os-release FILE.                |"
+		echo "|              PLEASE MANUALLY INSTALL THESE PACKAGES:              |"
+		echo "|                     ffmpeg git AND openssl                        |"
+		echo "|-------------------------------------------------------------------|"
+		
+		read -p "Press ENTER to continue" ENTER
+	fi
 }
 
 Backup()
 {
-   backupDirectory=$1
-   fileName=current-jellyfin-data.tar
-   if [[ $(echo "${backupDirectory: -1}") == "/" ]]; then
-      tarPath=$backupDirectory$fileName
-      echo "Saving your current metadata to --> $tarPath"
-   else
-      tarPath=$backupDirectory/$fileName
-      echo "Saving your current metadata to --> $tarPath"
-   fi
-   
-   cd $currentJellyfinDirectory
-   time tar cvf $tarPath data config
-   USER=$(stat -c '%U' $backupDirectory)
-   chown -f $USER:$USER $tarPath
-   chmod -f 660 $tarPath
+	backupDirectory=$1
+	fileName=current-jellyfin-data.tar
+	if [[ $(echo "${backupDirectory: -1}") == "/" ]]; then
+		tarPath=$backupDirectory$fileName
+		echo "Saving your current metadata to --> $tarPath"
+	else
+		tarPath=$backupDirectory/$fileName
+		echo "Saving your current metadata to --> $tarPath"
+	fi
+	
+	cd $currentJellyfinDirectory
+	time tar cvf $tarPath data config
+	USER=$(stat -c '%U' $backupDirectory)
+	chown -f $USER:$USER $tarPath
+	chmod -f 660 $tarPath
 }
 
 
 Previous_install()
 {
-   read -p "Is there a current install of Jellyfin on this system? [y/N] : " currentlyInstalled
+	read -p "Is there a current install of Jellyfin on this system? [y/N] : " currentlyInstalled
 
-   if [[ $currentlyInstalled == [yY]* ]]; then
-      isDataThere=false
-      isConfigThere=false
-      newDirectory=false
-      
-      while [ ! -d $currentJellyfinDirectory ]; do
-         read -p "Where is Jellyfins intalled directory? : " currentJellyfinDirectory
-         
-         #systemFileXML=$(find $currentJellyfinDirectory -name "system.xml")
-         #configPath=$(echo $systemFileXML | sed -r "s|/system.xml||g")
-         #metadataPath=$(grep -o "<MetadataPath>.*" $systemFileXML | sed -r "s|<MetadataPath>||g" | sed -r "s|</MetadataPath>||g")
-         #if [[ $configPath != *"config" ]]; then
-         #   echo "'config' folder not found"
-         #else
-         #   
-         #fi
-         
-         if [ ! -d "$currentJellyfinDirectory/data/metadata" ]; then
-            echo "$currentJellyfinDirectory/data/metadata does not exist"
-            isDataThere=false
-         else
-            isDataThere=true
-            echo "Found metadata!"
-         fi
+	if [[ $currentlyInstalled == [yY]* ]]; then
+		isDataThere=false
+		isConfigThere=false
+		newDirectory=false
+		
+		while [ ! -d $currentJellyfinDirectory ]; do
+			read -p "Where is Jellyfins intalled directory? : " currentJellyfinDirectory
+			
+			#systemFileXML=$(find $currentJellyfinDirectory -name "system.xml")
+			#configPath=$(echo $systemFileXML | sed -r "s|/system.xml||g")
+			#metadataPath=$(grep -o "<MetadataPath>.*" $systemFileXML | sed -r "s|<MetadataPath>||g" | sed -r "s|</MetadataPath>||g")
+			#if [[ $configPath != *"config" ]]; then
+			#	echo "'config' folder not found"
+			#else
+			#	
+			#fi
+			
+			if [ ! -d "$currentJellyfinDirectory/data/metadata" ]; then
+				echo "$currentJellyfinDirectory/data/metadata does not exist"
+				isDataThere=false
+			else
+				isDataThere=true
+				echo "Found metadata!"
+			fi
 
-         if [ ! -d "$currentJellyfinDirectory/config" ]; then
-            echo "$currentJellyfinDirectory/config does not exist"
-            isConfigThere=false
-         else
-            isConfigThere=true
-            echo "Found config!"
-         fi
+			if [ ! -d "$currentJellyfinDirectory/config" ]; then
+				echo "$currentJellyfinDirectory/config does not exist"
+				isConfigThere=false
+			else
+				isConfigThere=true
+				echo "Found config!"
+			fi
 
-         
-         if ! $isDataThere || ! $isConfigThere; then
-            echo "***ERROR*** - one or more directories not found..."
-            read -p "Would you like to try a different directory? [Y/n] : " newDirectory
-            
-            if [[ $newDirectory == [nN] ]]; then
-               exit
-            else
-               currentJellyfinDirectory=null
-            fi
-         fi
-         
-      done
-   
-   Backup $HOME
-   cd /opt/jellyfin
-   tar xvf $tarPath -C ./
-   
-   fi
+			
+			if ! $isDataThere || ! $isConfigThere; then
+				echo "***ERROR*** - one or more directories not found..."
+				read -p "Would you like to try a different directory? [Y/n] : " newDirectory
+				
+				if [[ $newDirectory == [nN] ]]; then
+					exit
+				else
+					currentJellyfinDirectory=null
+				fi
+			fi
+			
+		done
+	
+	Backup $HOME
+	cd /opt/jellyfin
+	tar xvf $tarPath -C ./
+	
+	fi
 }
 
 Setup()
 {
-   echo "Fetching newest stable Jellyfin version..."
-   Get_Architecture
-   jellyfin=
-   jellyfin_archive=
-   
-   if [ ! -f *"tar.gz" ]; then
-      wget https://repo.jellyfin.org/releases/server/linux/stable/combined/
-      jellyfin_archive=$(grep "$architecture.tar.gz" index.html | cut -d '"' -f 2 | sed -r "s|.sha256sum||g" | head -1)
-      rm index.html
-      wget https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
-      jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-   else
-      jellyfin_archive=$(ls *.tar.gz)
-      jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-   fi
-   
-   mkdir /opt/jellyfin
-   clear
-   Previous_install
+	echo "Fetching newest stable Jellyfin version..."
+	Get_Architecture
+	jellyfin=
+	jellyfin_archive=
+	
+	if [ ! -f *"tar.gz" ]; then
+		wget https://repo.jellyfin.org/releases/server/linux/stable/combined/
+		jellyfin_archive=$(grep "$architecture.tar.gz" index.html | cut -d '"' -f 2 | sed -r "s|.sha256sum||g" | head -1)
+		rm index.html
+		wget https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
+		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
+	else
+		jellyfin_archive=$(ls *.tar.gz)
+		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
+	fi
+	
+	mkdir /opt/jellyfin
+	clear
+	Previous_install
 
-   read -p "Please enter the default user for Jellyfin: " defaultUser
-   while id "$defaultUser" &>/dev/null; do
-      echo "Cannot create $defaultUser as $defaultUser already exists..."
-      read -p "Please re-enter a new default user for Jellyfin: " defaultUser
-   done
+	read -p "Please enter the default user for Jellyfin: " defaultUser
+	while id "$defaultUser" &>/dev/null; do
+		echo "Cannot create $defaultUser as $defaultUser already exists..."
+		read -p "Please re-enter a new default user for Jellyfin: " defaultUser
+	done
 
-   useradd -rd /opt/jellyfin $defaultUser
+	useradd -rd /opt/jellyfin $defaultUser
 
-   mkdir /opt/jellyfin/old /opt/jellyfin/backup
+	mkdir /opt/jellyfin/old /opt/jellyfin/backup
 
-   if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
-      cp $DIRECTORY/jellyman.1 /usr/share/man/man1/
-   elif [ -x "$(command -v dnf)" ] || [ -x "$(command -v zypper)" ]; then 
-      cp $DIRECTORY/jellyman.1 /usr/local/share/man/man1/
-   fi
+	if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
+		cp $DIRECTORY/jellyman.1 /usr/share/man/man1/
+	elif [ -x "$(command -v dnf)" ] || [ -x "$(command -v zypper)" ]; then 
+		cp $DIRECTORY/jellyman.1 /usr/local/share/man/man1/
+	fi
 
-   mkdir /opt/jellyfin/data /opt/jellyfin/cache /opt/jellyfin/config /opt/jellyfin/log /opt/jellyfin/cert
-   cp $DIRECTORY/scripts/jellyman /bin/
-   cp $DIRECTORY/scripts/jellyfin.sh /opt/jellyfin/
-   touch /opt/jellyfin/config/jellyman.conf
-   cp $jellyfin_archive /opt/jellyfin/
-   jellyfinServiceLocation=
-   
-   if [ -d /usr/lib/systemd/system ]; then
-      cp $DIRECTORY/conf/jellyfin.service /usr/lib/systemd/system/
-      jellyfinServiceLocation="/usr/lib/systemd/system/jellyfin.service"
-   else
-      cp $DIRECTORY/conf/jellyfin.service /etc/systemd/system/
-      jellyfinServiceLocation="/etc/systemd/system/jellyfin.service"
-   fi
-   
-   sed -i -e "s|User=jellyfin|User=$defaultUser|g" $jellyfinServiceLocation
-   cp $DIRECTORY/conf/jellyfin.conf /etc/
-   cd /opt/jellyfin
-   tar xvzf $DIRECTORY/$jellyfin_archive
-   rm -f $DIRECTORY/$jellyfin_archive
-   ln -s $jellyfin jellyfin
-   echo "architecture=$architecture" >> config/jellyman.conf
-   echo "defaultPath=" >> config/jellyman.conf
-   echo "apiKey=" >> config/jellyman.conf
-   echo "httpPort=8096" >> config/jellyman.conf
-   echo "httpsPort=8920" >> config/jellyman.conf
-   echo "currentVersion=$jellyfin" >> config/jellyman.conf
-   echo "defaultUser=$defaultUser" >> config/jellyman.conf
-   echo "jellyfinServiceLocation=$jellyfinServiceLocation" >> config/jellyman.conf
+	mkdir /opt/jellyfin/data /opt/jellyfin/cache /opt/jellyfin/config /opt/jellyfin/log /opt/jellyfin/cert
+	cp $DIRECTORY/scripts/jellyman /bin/
+	cp $DIRECTORY/scripts/jellyfin.sh /opt/jellyfin/
+	touch /opt/jellyfin/config/jellyman.conf
+	cp $jellyfin_archive /opt/jellyfin/
+	jellyfinServiceLocation=
+	
+	if [ -d /usr/lib/systemd/system ]; then
+		cp $DIRECTORY/conf/jellyfin.service /usr/lib/systemd/system/
+		jellyfinServiceLocation="/usr/lib/systemd/system/jellyfin.service"
+	else
+		cp $DIRECTORY/conf/jellyfin.service /etc/systemd/system/
+		jellyfinServiceLocation="/etc/systemd/system/jellyfin.service"
+	fi
+	
+	sed -i -e "s|User=jellyfin|User=$defaultUser|g" $jellyfinServiceLocation
+	cp $DIRECTORY/conf/jellyfin.conf /etc/
+	cd /opt/jellyfin
+	tar xvzf $DIRECTORY/$jellyfin_archive
+	rm -f $DIRECTORY/$jellyfin_archive
+	ln -s $jellyfin jellyfin
+	echo "architecture=$architecture" >> config/jellyman.conf
+	echo "defaultPath=" >> config/jellyman.conf
+	echo "apiKey=" >> config/jellyman.conf
+	echo "httpPort=8096" >> config/jellyman.conf
+	echo "httpsPort=8920" >> config/jellyman.conf
+	echo "currentVersion=$jellyfin" >> config/jellyman.conf
+	echo "defaultUser=$defaultUser" >> config/jellyman.conf
+	echo "jellyfinServiceLocation=$jellyfinServiceLocation" >> config/jellyman.conf
 
-   Install_dependancies
+	Install_dependancies
 
-   echo "Setting Permissions for Jellyfin..."
-   chown -R $defaultUser:$defaultUser /opt/jellyfin
-   chmod u+x jellyfin.sh
-   chmod +x /bin/jellyman
+	echo "Setting Permissions for Jellyfin..."
+	chown -R $defaultUser:$defaultUser /opt/jellyfin
+	chmod u+x jellyfin.sh
+	chmod +x /bin/jellyman
 
-   echo "Unblocking port 8096 and 8920..."
-   if [ -x "$(command -v ufw)" ]; then
-      ufw allow 8096/tcp
-      ufw allow 8920/tcp
-      ufw reload
-   elif [ -x "$(command -v firewall-cmd)" ]; then
-      firewall-cmd --permanent --zone=public --add-port=8096/tcp
-      firewall-cmd --permanent --zone=public --add-port=8920/tcp
-      firewall-cmd --reload
-   else
-      echo "|-------------------------------------------------------------------|"
-      echo "|                        ******WARNING******                        |"
-      echo "|                         ******ERROR******                         |"
-      echo "|                  FAILED TO OPEN PORT 8096/8920!                   |"
-      echo "|          ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!          |"
-      echo "|-------------------------------------------------------------------|"
-   fi
+	echo "Unblocking port 8096 and 8920..."
+	if [ -x "$(command -v ufw)" ]; then
+		ufw allow 8096/tcp
+		ufw allow 8920/tcp
+		ufw reload
+	elif [ -x "$(command -v firewall-cmd)" ]; then
+		firewall-cmd --permanent --zone=public --add-port=8096/tcp
+		firewall-cmd --permanent --zone=public --add-port=8920/tcp
+		firewall-cmd --reload
+	else
+		echo "|-------------------------------------------------------------------|"
+		echo "|                        ******WARNING******                        |"
+		echo "|                         ******ERROR******                         |"
+		echo "|                  FAILED TO OPEN PORT 8096/8920!                   |"
+		echo "|          ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!          |"
+		echo "|-------------------------------------------------------------------|"
+	fi
 
-   echo
-   echo
-   echo "DONE"
-   echo
-   echo "|-------------------------------------------------------------------|"
-   echo "|               Navigate to http://localhost:8096/                  |"
-   echo "|        in your Web Browser to claim your Jellyfin server          |"
-   echo "|-------------------------------------------------------------------|"
-   echo
-   echo "|-------------------------------------------------------------------|"
-   echo "|         To enable https please enter 'sudo jellyman -rc'          |"
-   echo "|       (After you have navigated to the Jellyfin Dashboard)        |"
-   echo "|                                                                   |"
-   echo "|             To manage Jellyfin use 'jellyman -h'                  |"
-   echo "|-------------------------------------------------------------------|"
-   echo
-   if $os_detected; then
-      read -p "Press ENTER to continue" ENTER
-      jellyman -h -e -s
-   else
-      jellyman -h 
-      echo "|-------------------------------------------------------------------|"
-      echo "|                        ******WARNING******                        |"
-      echo "|             JELLYFIN MEDIA SERVER NOT ENABLED OR STARTED          |"
-      echo "|                  FAILED TO FIND /etc/os-release FILE.             |"
-      echo "|                PLEASE MANUALLY INSTALL THESE PACKAGES:            |"
-      echo "|                       ffmpeg git AND openssl                      |"
-      echo "|        THEN RUN: jellyman -e -s TO ENABLE AND START JELLYFIN      |"
-      echo "|-------------------------------------------------------------------|"
-   fi
-   echo
-   read -p " Press ENTER to continue" ENTER
-   echo "Press 'q' to exit next screen"
-   read -p " Press ENTER to continue" ENTER
-   jellyman -t
-   echo
-   read -p "Would you like to remove the cloned git directory $DIRECTORY? [Y/n] : " deleteOrNot
-   if [[ $deleteOrNot == [nN]* ]]; then
-      echo "Okay, keeping $DIRECTORY"
-   else
-      echo "Removing cloned git directory:$DIRECTORY..."
-      rm -rf $DIRECTORY
-   fi
+	echo
+	echo
+	echo "DONE"
+	echo
+	echo "|-------------------------------------------------------------------|"
+	echo "|                 Navigate to http://localhost:8096/                |"
+	echo "|         in your Web Browser to claim your Jellyfin server         |"
+	echo "|-------------------------------------------------------------------|"
+	echo
+	echo "|-------------------------------------------------------------------|"
+	echo "|         To enable https please enter 'sudo jellyman -rc'          |"
+	echo "|       (After you have navigated to the Jellyfin Dashboard)        |"
+	echo "|                                                                   |"
+	echo "|                To manage Jellyfin use 'jellyman -h'               |"
+	echo "|-------------------------------------------------------------------|"
+	echo
+	if $os_detected; then
+		read -p "Press ENTER to continue" ENTER
+		jellyman -h -e -s
+	else
+		jellyman -h 
+		echo "|-------------------------------------------------------------------|"
+		echo "|                        ******WARNING******                        |"
+		echo "|            JELLYFIN MEDIA SERVER NOT ENABLED OR STARTED           |"
+		echo "|               FAILED TO FIND /etc/os-release FILE.                |"
+		echo "|             PLEASE MANUALLY INSTALL THESE PACKAGES:               |"
+		echo "|                     ffmpeg git AND openssl                        |"
+		echo "|       THEN RUN: jellyman -e -s TO ENABLE AND START JELLYFIN       |"
+		echo "|-------------------------------------------------------------------|"
+	fi
+	echo
+	read -p " Press ENTER to continue" ENTER
+	echo "Press 'q' to exit next screen"
+	read -p " Press ENTER to continue" ENTER
+	jellyman -t
+	echo
+	read -p "Would you like to remove the cloned git directory $DIRECTORY? [Y/n] : " deleteOrNot
+	if [[ $deleteOrNot == [nN]* ]]; then
+		echo "Okay, keeping $DIRECTORY"
+	else
+		echo "Removing cloned git directory:$DIRECTORY..."
+		rm -rf $DIRECTORY
+	fi
 }
 
 Pre_setup()
 {
-   echo "|-------------------------------------------------------------------|"
-   echo "|                     No commands recognized                        |"
-   echo "|                      setup.sh options are:                        |"
-   echo "|                                                                   |"
-   echo "|  -i [jellyfin-backup.tar] Import .tar to pick up where you left   |" 
-   echo "|                    off on another machine                         |"
-   echo "|                                                                   |"
-   echo "|                    -U Update Jellyman only.                       |"
-   echo "|-------------------------------------------------------------------|"
-   echo
-   echo "Press ENTER to continue with first time setup or CTRL+C to exit..."
-   read ENTER
+	echo "|-------------------------------------------------------------------|"
+	echo "|                    No commands recognized                         |"
+	echo "|                     setup.sh options are:                         |"
+	echo "|                                                                   |"
+	echo "|  -i [jellyfin-backup.tar] Import .tar to pick up where you left   |"
+	echo "|                    off on another machine                         |"
+	echo "|                                                                   |"
+	echo "|                    -U Update Jellyman only.                       |"
+	echo "|-------------------------------------------------------------------|"
+	echo
+	echo "Press ENTER to continue with first time setup or CTRL+C to exit..."
+	read ENTER
 }
 
 Update_jellyman()
 {
-   Has_sudo
-   source /opt/jellyfin/config/jellyman.conf
-   echo "Updating Jellyman - The Jellyfin Manager"
-   cp -f scripts/jellyman /bin/jellyman
-   chmod +x /bin/jellyman
-   if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
-      cp jellyman.1 /usr/share/man/man1/
-   elif [ -x "$(command -v dnf)" ] || [ -x "$(command -v zypper)" ]; then 
-      cp jellyman.1 /usr/local/share/man/man1/
-   fi
-   
-   if ( ! grep -q apiKey= "/opt/jellyfin/config/jellyman.conf" ); then
-      echo "apiKey=" >> /opt/jellyfin/config/jellyman.conf
-   fi
+	Has_sudo
+	source /opt/jellyfin/config/jellyman.conf
+	echo "Updating Jellyman - The Jellyfin Manager"
+	cp -f scripts/jellyman /bin/jellyman
+	chmod +x /bin/jellyman
+	if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
+		cp jellyman.1 /usr/share/man/man1/
+	elif [ -x "$(command -v dnf)" ] || [ -x "$(command -v zypper)" ]; then 
+		cp jellyman.1 /usr/local/share/man/man1/
+	fi
+	
+	if ( ! grep -q apiKey= "/opt/jellyfin/config/jellyman.conf" ); then
+		echo "apiKey=" >> /opt/jellyfin/config/jellyman.conf
+	fi
 
-   if ( ! grep -q networkPort= "/opt/jellyfin/config/jellyman.conf" ) && ( ! grep -q httpPort= "/opt/jellyfin/config/jellyman.conf" ); then
-      echo "networkPort=8096" >> /opt/jellyfin/config/jellyman.conf
-   elif ( ! grep -q httpPort= "/opt/jellyfin/config/jellyman.conf" ) || ( ! grep -q httpsPort= "/opt/jellyfin/config/jellyman.conf" ); then
-      sed -i -e "s|networkPort=.*|httpPort=8096|g" /opt/jellyfin/config/jellyman.conf
-      echo "httpsPort=8920" >> /opt/jellyfin/config/jellyman.conf
-   fi
-   
-   if [ -d /usr/lib/systemd ] && [[ ! -n $jellyfinServiceLocation ]]; then
-      bash -c 'echo "jellyfinServiceLocation=/usr/lib/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf'
-   elif [[ ! -n $jellyfinServiceLocation ]]; then
-      bash -c 'echo "jellyfinServiceLocation=/etc/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf'
-   fi
+	if ( ! grep -q networkPort= "/opt/jellyfin/config/jellyman.conf" ) && ( ! grep -q httpPort= "/opt/jellyfin/config/jellyman.conf" ); then
+		echo "networkPort=8096" >> /opt/jellyfin/config/jellyman.conf
+	elif ( ! grep -q httpPort= "/opt/jellyfin/config/jellyman.conf" ) || ( ! grep -q httpsPort= "/opt/jellyfin/config/jellyman.conf" ); then
+		sed -i -e "s|networkPort=.*|httpPort=8096|g" /opt/jellyfin/config/jellyman.conf
+		echo "httpsPort=8920" >> /opt/jellyfin/config/jellyman.conf
+	fi
+	
+	if [ -d /usr/lib/systemd ] && [[ ! -n $jellyfinServiceLocation ]]; then
+		bash -c 'echo "jellyfinServiceLocation=/usr/lib/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf'
+	elif [[ ! -n $jellyfinServiceLocation ]]; then
+		bash -c 'echo "jellyfinServiceLocation=/etc/systemd/system/jellyfin.service" >> /opt/jellyfin/config/jellyman.conf'
+	fi
 
-   if [[ ! -n $architecture ]]; then
-      architecture=
-      Get_Architecture
-      echo "architecture=$architecture" >> /opt/jellyfin/config/jellyman.conf
-   fi
+	if [[ ! -n $architecture ]]; then
+		architecture=
+		Get_Architecture
+		echo "architecture=$architecture" >> /opt/jellyfin/config/jellyman.conf
+	fi
 
-   echo "...complete"
+	echo "...complete"
 }
 
 
 if [ -n "$1" ]; then
-   while [ -n "$1" ]; do
-      case "$1" in
-         -i)   Import $2
-               rm -rf $DIRECTORY
-               exit ;;
-         -U)   Update_jellyman
-               rm -rf $DIRECTORY
-               exit ;;
-         *)    Pre_setup 
-               setup  ;;
-      esac
-      shift
-   done
+	while [ -n "$1" ]; do
+		case "$1" in
+			-i)	Import $2
+					rm -rf $DIRECTORY
+					exit ;;
+			-U)	Update_jellyman
+					rm -rf $DIRECTORY
+					exit ;;
+			*)	 Pre_setup 
+					setup  ;;
+		esac
+		shift
+	done
 else
-   Pre_setup
-   Setup
-   exit
+	Pre_setup
+	Setup
+	exit
 fi
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -124,7 +124,7 @@ Install_dependancies()
 		os_detected=true
 		echo "ID=$ID"
 		
-		if [[ $ID_LIKE == *"rhel"* ]] || [[ $ID == "rhel" ]]; then
+		if [[ $ID_LIKE == .*"rhel".* ]] || [[ $ID == "rhel" ]]; then
 			ID=rhel
 			
 			if [[ $VERSION_ID == *"."* ]]; then
@@ -254,9 +254,8 @@ Setup()
 	jellyfin_archive=
 	
 	if [ ! -f *"tar.gz" ]; then
-		wget https://repo.jellyfin.org/releases/server/linux/stable/combined/
-		jellyfin_archive=$(grep "$architecture.tar.gz" index.html | cut -d '"' -f 2 | sed -r "s|.sha256sum||g" | head -1)
-		rm index.html
+		jellyfinIndex=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable/combined/)
+		jellyfin_archive=$(echo "$jellyfinIndex" | grep -o jellyfin_[0-9][0-9].[0-9].[0-9].$architecture.tar.gz | head -1)
 		wget https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
 	else
@@ -288,7 +287,6 @@ Setup()
 	cp $DIRECTORY/scripts/jellyman /bin/
 	cp $DIRECTORY/scripts/jellyfin.sh /opt/jellyfin/
 	touch /opt/jellyfin/config/jellyman.conf
-	cp $jellyfin_archive /opt/jellyfin/
 	jellyfinServiceLocation=
 	
 	if [ -d /usr/lib/systemd/system ]; then
@@ -303,7 +301,6 @@ Setup()
 	cp $DIRECTORY/conf/jellyfin.conf /etc/
 	cd /opt/jellyfin
 	tar xvzf $DIRECTORY/$jellyfin_archive
-	rm -f $DIRECTORY/$jellyfin_archive
 	ln -s $jellyfin jellyfin
 	echo "architecture=$architecture" >> config/jellyman.conf
 	echo "defaultPath=" >> config/jellyman.conf


### PR DESCRIPTION
### Added
- Added some printable output to `jellyman -tc` for readability
- Added ability to `jellyman -tc` to select preset and CRF (quality settings)

### Changed
- Changed tabulations from 3 hard spaces to 2 tab spaces.
- Changed all wget commands t o `curl -sL` commands for less terminal spam.
- Changed interactive prompts for `jellyman -u` and  `jellyman -ub` commands
- Changed `jellyman -vs -vd -rv` functions to not exit unless a proper input is detected, CTRL+C to exit this.
