### PR TITLE
Fixed update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.6.7 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.6.8 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34/35/36, Ubuntu 22.04, Manjaro 21.3.6, EndeavourOS Artemis Neo, Linux Mint 21, and Rocky Linux 8.6/9.0
 

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.6.7
+.B Jellyman - The Jellyfin Manager - v1.6.8
 
 .SH SYNOPSIS
 .B jellyman

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.6.7"
+jellymanVersion="v1.6.8"
 sourceFile="/opt/jellyfin/config/jellyman.conf"
 
 ###############################################################################
@@ -464,7 +464,7 @@ Update()
 		echo "Getting current version from repository..."
 		mkdir /opt/jellyfin/update
 		stableReleases=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable/combined/)
-		jellyfin_archive=$(echo $stableReleases | grep -o "jellyfin_"[0-9][0-9].[0-9].[0-9]"_$architecture.tar.gz" | head -1)
+		jellyfin_archive=$(echo $stableReleases | grep -o "jellyfin_"[0-9][0-9].[0-9]*.[0-9]*"_$architecture.tar.gz" | head -1)
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
 		
 		echo "jellyfin_archive = $jellyfin_archive"


### PR DESCRIPTION
Jellyfin recently updated to 10.8.10, however the script did not account for double digits in the 10.8.XX.