### PR TITLE
Fixes #54 - Jellyfin Release Grep Fix

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -254,8 +254,7 @@ Setup()
 	jellyfin_archive=
 	
 	if [ ! -f *"tar.gz" ]; then
-		jellyfinIndex=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable/combined/)
-		jellyfin_archive=$(echo "$jellyfinIndex" | grep -o jellyfin_[0-9][0-9].[0-9].[0-9].$architecture.tar.gz | head -1)
+		jellyfin_archive=$(curl -sL https://repo.jellyfin.org/releases/server/linux/stable/combined/ | grep -Po jellyfin_[^_]+_$architecture.tar.gz | head -1)
 		wget https://repo.jellyfin.org/releases/server/linux/stable/combined/$jellyfin_archive
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
 	else


### PR DESCRIPTION
The current code for grabbing the latest version of Jellyfin is not working.  The existing grep looks for single digit patch numbers: `jellyfin_[0-9][0-9].[0-9].[0-9].$architecture`.  The latest version of Jellyfin is `10.8.13`, which has a two-digit patch number.  In this PR, I've changed the grep to use a Perl expression that looks for any group of text in between two underscores, followed by the architecture: `jellyfin_[^_]+_$architecture`.

Additionally, the `curl` command that pulls in the releases was being brought into a variable; in testing on Ubuntu 22.04 I found only the first line of the page results was being pulled into that variable.  Since there's no need to store that as a shell variable I've instead combined the curl command into the existing `jellyfinArchive` variable line and piped that directly into the grep command.