### PR TITLE
Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.7.1 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.7.2 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34-40, Ubuntu 22.04/22.10, Manjaro 21.3.6, EndeavourOS Artemis Neo/Nova & Cassini Nova, Linux Mint 21, and Rocky Linux 8.6/9.0
 

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.7.1
+.B Jellyman - The Jellyfin Manager - v1.7.2
 
 .SH SYNOPSIS
 .B jellyman
@@ -45,7 +45,7 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .B -t, --status                 Status of Jellyfin.
 .TP
 .B -u, --update-jellyfin        [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
-└── NOTE - Supplied URL has to end with jellyfin_x.x.x_<ARCHITECTURE>.tar.gz
+└── NOTE - Supplied URL has to end with jellyfin_xx.x.x-<ARCHITECTURE>.tar.gz
 .TP
 .B -U, --update-jellyman        Update Jellyman - The CLI Tool.
 └── Checks and downloads most recent version from GitHub.
@@ -105,8 +105,8 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 
 .SH URL TO NEW VERSIONS
 .PP
-***WARNING*** ONLY USE COMBINED(Web & Server) PACKAGES
-https://repo.jellyfin.org/releases/server/linux/versions/
+List of supported official Jellyfin packages:
+https://repo.jellyfin.org/files/server/linux/stable/
 
 .SH COPYRIGHT
 .PP

--- a/scripts/jellyfin.sh
+++ b/scripts/jellyfin.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 JELLYFINDIR=/opt/jellyfin 
-FFMPEGDIR=/usr/share/ffmpeg 
+FFMPEGDIR=/usr/bin/ffmpeg
 
 $JELLYFINDIR/jellyfin/jellyfin \
  -d $JELLYFINDIR/data \
  -C $JELLYFINDIR/cache \
  -c $JELLYFINDIR/config \
  -l $JELLYFINDIR/log \
- --ffmpeg $FFMPEGDIR/ffmpeg 
+ --ffmpeg $FFMPEGDIR

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.7.1"
+jellymanVersion="v1.7.2"
 sourceFile="/opt/jellyfin/config/jellyman.conf"
 
 ###############################################################################
@@ -126,14 +126,14 @@ Download_version()
 	Has_sudo
 	source $sourceFile
 	versionListVar=$(curl -sL https://repo.jellyfin.org/files/server/linux/stable/)
-	versionList=$(echo "$versionListVar" | grep ':' | cut -d '>' -f 2 | cut -d '/' -f 1)
+	versionList=$(echo "$versionListVar" | grep '>v' | cut -d '>' -f 2 | cut -d '/' -f 1)
 	versionListNumbered=$(echo "$versionList" | cat -n)
 	maxNumber=$(echo "$versionList" | wc -l)
 	newVersionNumber=""
 	versionToSwitchNumber=0
 	warning=""
 
-	while (( $versionToSwitchNumber > $maxNumber )) && (( $versionToSwitchNumber < 1 )); do
+	while (( $versionToSwitchNumber > $maxNumber )) || (( $versionToSwitchNumber < 1 )); do
 		clear
 		echo "**WARNING** If Jellyfin v10.9.0 or later has been installed, it is impossible to revert to older versions as they will no longer be supported by Jellyman"
 		echo "Current Jellyfin version installed"
@@ -146,7 +146,7 @@ Download_version()
 		read -p "the version you want to install [1-$maxNumber] : " versionToSwitchNumber
 		newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1)
 
-		if [[ $versionToSwitchNumber > $maxNumber && $versionToSwitchNumber < 1 ]]; then
+		if [[ $versionToSwitchNumber > $maxNumber || $versionToSwitchNumber < 1 ]]; then
 			versionToSwitchnumber=0
 			warning="ERROR: Please select one of the numbers provided!"
 			echo "Press CTRL+C to exit..."
@@ -443,14 +443,16 @@ Update()
 	jellyfin_archive=""
 	jellyfin=""
 	new_jellyfin_version=""
+	newJellyfinArchive=""
 	
 	if [[ $1 == *"://"* ]] ; then 
 		echo "Fetching custom Jellyfin version..."
 		customVersionLink=$1
 		customVersion=$(echo $customVersionLink | rev | cut -d/ -f1 | rev)
 		jellyfin_archive=$customVersion
-		jellyfin=$(echo $jellyfin_archive | sed -r "s|_$architecture.tar.gz||g")
-		fileType=$(echo $customVersion | cut -d_ -f3)
+		newJellyfinArchive=$jellyfin_archive
+		jellyfin=$(echo $jellyfin_archive | sed -r "s|-$architecture.tar.gz||g")
+		fileType=$(echo $customVersion | cut -d '-' -f2)
 		
 		if isInstalledVersion $jellyfin; then
 			exit
@@ -470,7 +472,7 @@ Update()
 		stableReleases=$(curl -sL https://repo.jellyfin.org/?path=/server/linux/latest-stable/$architecture/)
 		jellyfin_archive=$(echo "$stableReleases" | grep -Po jellyfin_[^_]+-$architecture.tar.gz | head -1)
 		jellyfin=$(echo "$jellyfin_archive" | sed -r "s|-$architecture.tar.gz||g")
-		newJellyfinArchive=$(echo "$jellyfin"_$architecture.tar.gz)
+		newJellyfinArchive=$(echo "$jellyfin"-$architecture.tar.gz)
 		
 		echo "jellyfin_archive = $jellyfin_archive"
 		echo "jellyfin = $jellyfin"
@@ -483,7 +485,7 @@ Update()
 	fi
 	
 	new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
-	echo "Unpacking $jellyfin_archive to /opt/jellyfin/..."
+	echo "Unpacking $jellyfin_archive to /opt/jellyfin/$jellyfin"
 	jellyman -S
 	unlink /opt/jellyfin/jellyfin
 	tar xvzf /opt/jellyfin/update/$newJellyfinArchive -C /opt/jellyfin/
@@ -1103,8 +1105,7 @@ Help()
 	echo "-X, --uninstall              Uninstall Jellyfin and Jellyman Completely."
 	echo
 	echo "To browse Jellyfin versions please use this link."
-	echo "***WARNING*** ONLY USE COMBINED(Web & Server) PACKAGES"
-	echo "https://repo.jellyfin.org/releases/server/linux/versions/"
+	echo "https://repo.jellyfin.org/files/server/linux/stable/"
 }
 
 ###############################################################################

--- a/setup.sh
+++ b/setup.sh
@@ -401,6 +401,7 @@ Update_jellyman()
 	source /opt/jellyfin/config/jellyman.conf
 	echo "Updating Jellyman - The Jellyfin Manager"
 	cp -f scripts/jellyman /bin/jellyman
+	cp -f scripts/jellyfin.sh /opt/jellyfin/jellyfin.sh
 	chmod +x /bin/jellyman
 	if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
 		cp jellyman.1 /usr/share/man/man1/


### PR DESCRIPTION
- Fixed /opt/jellyfin/jellyfin.sh not pointing to correct ffmpeg binary. (When did this change?!?!)
- Fixed various issues with `jellyman -h` and `man jellyman`
- Added `jellyman -U` to update the `/opt/jellyfin/jellyfin.sh` file