### PR TITLE
Update from 1.7.6 to 1.7.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.7.6 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.7.7 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34-40, Ubuntu 22.04-24.04, Manjaro 21.3.6, EndeavourOS Artemis Neo/Nova/Cassini Nova, Linux Mint 21, and Rocky/Alma/RHEL Linux 8.6/9.0
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ COMMANDS:
 -d, --disable                Disable Jellyfin on System Start.
 -e, --enable                 Enable Jellyfin on System Start.
 -h, --help                   Print this Help.
--i, --import                 [FILE.tar] Input file to Import jellyfin-backup.tar.
+-i, --import                 [FILE.tar - optional] Input file to Import jellyfin-backup.tar.
 -p, --permissions            [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory.
 -r, --restart                Restart Jellyfin.
 -s, --start                  Start Jellyfin.

--- a/README.md
+++ b/README.md
@@ -248,10 +248,11 @@ EXAMPLE:
 ### In case Jellyman wont upgrade itself
 
 ```shell
-git clone https://github.com/Smiley-McSmiles/jellyman
+git clone https://github.com/Smiley-McSmiles/jellyman.git
 cd jellyman
 chmod ug+x setup.sh
 sudo ./setup.sh -U
+cd ~/
 ```
 
 ### License

--- a/jellyman.1
+++ b/jellyman.1
@@ -34,7 +34,7 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .TP
 .B -h, --help                   Print this Help.
 .TP
-.B -i, --import                 [FILE.tar] Input file to Import jellyfin-backup.tar.
+.B -i, --import                 [FILE.tar - optional] Input file to Import jellyfin-backup.tar.
 └── This will only work if on your new OS/setup you have your Media directories exactly the same as your old OS/setup.
 .TP
 .B -p, --permissions            [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory.

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.7.6
+.B Jellyman - The Jellyfin Manager - v1.7.7
 
 .SH SYNOPSIS
 .B jellyman

--- a/scripts/base_functions.sh
+++ b/scripts/base_functions.sh
@@ -12,18 +12,23 @@ Prompt_user()
 	_promptText="$2"
 	_minNumber=$3
 	_maxNumber=$4
+	_inputText=$5
 	_yesOrNo=null
 	_dir=null
 	_file=null
 	_num=null
 	_usr=NULL
 	_str=
+	
 	echo "$_promptText"
 	
 	case $_promptType in
 		"Yn")
+			if [[ ! -n $_inputText ]]; then
+				_inputText="Y/n"
+			fi
 			while [[ ! $_yesOrNo == [yY][eE][sS] ]] || [[ ! $_yesOrNo == [yY] ]] || [[ ! $_yesOrNo == [nN][oO] ]] || [[ ! $_yesOrNo == [nN] ]] || [[ ! $_yesOrNo == "" ]]; do
-				read -p "[Y/n] >>> " _yesOrNo
+				read -p "[$_inputText] >>> " _yesOrNo
 				if [[ $_yesOrNo == "" ]] || [[ $_yesOrNo == [yY][eE][sS] ]] || [[ $_yesOrNo == [yY] ]]; then
 					return 0
 				elif [[ $_yesOrNo == [nN][oO] ]] || [[ $_yesOrNo == [nN] ]]; then
@@ -36,8 +41,11 @@ Prompt_user()
 			done
 		;;
 		"yN")
+			if [[ ! -n $_inputText ]]; then
+				_inputText="y/N"
+			fi
 			while [[ ! $_yesOrNo == [yY][eE][sS] ]] || [[ ! $_yesOrNo == [yY] ]] || [[ ! $_yesOrNo == [nN][oO] ]] || [[ ! $_yesOrNo == [nN] ]] || [[ ! $_yesOrNo == "" ]]; do
-				read -p "[y/N] >>> " _yesOrNo
+				read -p "[$_inputText] >>> " _yesOrNo
 				if [[ $_yesOrNo == [yY][eE][sS] ]] || [[ $_yesOrNo == [yY] ]]; then
 					return 0
 				elif [[ $_yesOrNo == "" ]] || [[ $_yesOrNo == [nN][oO] ]] || [[ $_yesOrNo == [nN] ]]; then
@@ -50,8 +58,11 @@ Prompt_user()
 			done
 		;;
 		"dir")
+			if [[ ! -n $_inputText ]]; then
+				_inputText="/path/to/directory"
+			fi
 			while [[ ! -d $_dir ]]; do
-				read -p "[/path/to/directory] >>> " "_dir"
+				read -p "[$_inputText] >>> " "_dir"
 				if [[ -d $_dir ]]; then
 					promptDir="$_dir"
 					return 0
@@ -62,8 +73,11 @@ Prompt_user()
 			done
 		;;
 		"file")
+			if [[ ! -n $_inputText ]]; then
+				_inputText="/path/to/file"
+			fi
 			while [[ ! -f $_file ]]; do
-				read -p "[/path/to/file] >>> " "_file"
+				read -p "[$_inputText] >>> " "_file"
 				if [[ -f $_file ]]; then
 					promptFile="$_file"
 					return 0
@@ -74,8 +88,11 @@ Prompt_user()
 			done
 		;;
 		"num")
+			if [[ ! -n $_inputText ]]; then
+				_inputText="$_minNumber-$_maxNumber"
+			fi
 			while [[ ! $_num =~ ^[0-9]+$ ]]; do
-				read -p "[number] >>> " _num
+				read -p "[$_inputText] >>> " _num
 				if [[ $_num -lt $_minNumber ]] || [[ $_num -gt $_maxNumber ]]; then
 					echo
 					_num=null
@@ -90,9 +107,12 @@ Prompt_user()
 			done
 		;;
 		"usr")
-			while [[ "$_usr" =~ [A-Z] ]] || [[ "$_usr" =~ \ |\' ]]; do
-				read -p "[username] >>> " "_usr"
-				if [[ ! "$_usr" =~ [A-Z] ]] && [[ ! "$_usr" =~ \ |\' ]]; then
+			if [[ ! -n $_inputText ]]; then
+				_inputText="username"
+			fi
+			while [[ "$_usr" =~ [A-Z] ]] || [[ "$_usr" =~ \ |\' ]] || [[ "$_usr" == "" ]]; do
+				read -p "[$_inputText] >>> " "_usr"
+				if [[ ! "$_usr" =~ [A-Z] ]] && [[ ! "$_usr" =~ \ |\' ]] && [[ ! "$_usr" == "" ]]; then
 					promptUsr=$_usr
 					return 0
 				else
@@ -102,8 +122,11 @@ Prompt_user()
 			done
 		;;
 		"str")
+			if [[ ! -n $_inputText ]]; then
+				_inputText="string"
+			fi
 			while [[ ! -n $_str ]]; do
-				read -p "[string] >>> " "_str"
+				read -p "[$_inputText] >>> " "_str"
 				if [[ -n $_str ]]; then
 					promptUsr=$_str
 					return 0
@@ -118,37 +141,37 @@ Prompt_user()
 		;;
 	esac
 # Default yes
-# if Prompt_user Yn "Example yes or no question?"; then
+# if Prompt_user Yn "Example yes or no question?" 0 0 "Y/n"; then
 #	echo "pass"
 # else
 #	echo "fail"
 # fi
 
 # Default no
-# if Prompt_user yN "Example yes or no question?"; then
+# if Prompt_user yN "Example yes or no question?" 0 0 "y/N"; then
 #	echo "pass"
 # else
 #	echo "fail"
 # fi
 
 # Check for directory, return directory
-# Prompt_user dir "Enter a valid directory"
+# Prompt_user dir "Enter a valid directory" 0 0 "/path/to/directory"
 # echo "Directory entered = $promptDir"
 
 # Check for file, return file
-# Prompt_user file "Enter a valid file"
+# Prompt_user file "Enter a valid file" 0 0 "/path/to/file"
 # echo "File entered = $promptFile"
 
 # Check if number, return number entered
-# Prompt_user num "Enter a valid number" minNumber maxNumber
+# Prompt_user num "Enter a valid number" minNumber maxNumber "$minNumber-$maxNumber"
 # echo "Number entered = $promptNum"
 
 # Check username for uppercase or spaces, return username
-# Prompt_user usr "Enter a valid username"
+# Prompt_user usr "Enter a valid username" 0 0 "username"
 # echo "Username entered = $promptUsr"
 
 # Check if string variable is not empty, return string
-# Prompt_user str "Enter a string"
+# Prompt_user str "Enter a string" 0 0 "string"
 # echo "String entered = $promptStr"
 }
 

--- a/scripts/base_functions.sh
+++ b/scripts/base_functions.sh
@@ -152,25 +152,45 @@ Prompt_user()
 # echo "String entered = $promptStr"
 }
 
-Change_variable()
+Set_var()
 {
-	# Change_variable testVar "newVarContent" varType "fileToChange"
+	# Set_var testVar "newVarContent" "fileToChange" varType
 	varToChange=$1
 	newVarContent=$2
 	fileToChange=$3
 	varType=$4
-	if [[ ! -n $varToChange ]] || [[ ! -n $newVarContent ]]; then
-		echo "Function Change_variable requires 3 parameters: varToChange newVarContent fileToChange"
-		exit
-	elif [[ $varType == "array" ]]; then
-		sed -i "s|$varToChange=.*|$varToChange=\($newVarContent\)|g" $fileToChange
+	if ( ! grep -q $varToChange "$fileToChange" ); then
+		echo "$varToChange=$newVarContent" >> $fileToChange
 	else
-		sed -i "s|$varToChange=.*|$varToChange=$newVarContent|g" $fileToChange
+		if [[ ! -n $varToChange ]] || [[ ! -n $newVarContent ]]; then
+			echo "Function Change_variable requires 3 parameters: varToChange newVarContent fileToChange"
+			return 1
+			exit
+		elif [[ $varType == "array" ]]; then
+			sed -i "s|$varToChange=.*|$varToChange=\($newVarContent\)|g" $fileToChange
+			return 0
+		else
+			sed -i "s|$varToChange=.*|$varToChange=$newVarContent|g" $fileToChange
+			return 0
+		fi
 	fi
-	
 }
 
-Change_xml_variable()
+Del_var()
+{
+	# Del_var varToDelete fileToChange
+	varToDelete=$1
+	fileToChange=$2
+	if ( ! grep -q $varToChange "$fileToChange" ); then
+		echo "ERROR: Variable $varToChange is not in $fileToChange"
+		return 1
+	else
+		sed -i "/$varToDelete/d" $fileToChange
+		return 0
+	fi
+}
+
+Set_xml_var()
 {
 	# Change_xml_variable testVar "newVarContent" "fileToChange"
 	varToChange=$1
@@ -178,9 +198,11 @@ Change_xml_variable()
 	fileToChange=$3
 	if [[ ! -n $varToChange ]] || [[ ! -n $newVarContent ]] && [[ ! $fileToChange == *".xml" ]]; then
 		echo "Function Change_xml_variable requires 3 parameters: varToChange newVarContent fileToChange"
+		return 1
 		exit
 	else
 		sed -i "s|<$varToChange>.*</$varToChange>|<$varToChange>$newVarContent</$varToChange>|g" $fileToChange
+		return 0
 	fi
 }
 
@@ -211,8 +233,11 @@ Has_sudo()
 	if [ "$EUID" -ne 0 ]; then
 		echo "ERROR: Permission denied for $USER"
 		echo "This command requires root privileges"
+		return 1
 		exit
-    	fi
+	else
+		return 0
+	fi
 }
 
 areDirectories()

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1009,24 +1009,20 @@ Transcode()
 	desiredGBperHour=$promptStr
 	
 	preset=0
-	while [ $preset -gt 9 ] || [ $preset -lt 1 ]; do
-		clear
-		echo
-		echo "> 1: ultrafast"
-		echo "> 2: superfast"
-		echo "> 3: veryfast"
-		echo "> 4: faster"
-		echo "> 5: fast"
-		echo '> 6: medium (RECOMMENDED)'
-		echo "> 7: slow"
-		echo "> 8: slower"
-		echo "> 9: veryslow"
-		echo
-		Prompt_user num "> Please choose a transcode preset" 1 9
-		preset=$promptNum
-		 preset=0
-		fi
-	done
+	clear
+	echo
+	echo "> 1: ultrafast"
+	echo "> 2: superfast"
+	echo "> 3: veryfast"
+	echo "> 4: faster"
+	echo "> 5: fast"
+	echo '> 6: medium (RECOMMENDED)'
+	echo "> 7: slow"
+	echo "> 8: slower"
+	echo "> 9: veryslow"
+	echo
+	Prompt_user num "> Please choose a transcode preset" 1 9
+	preset=$promptNum
 	echo
 	case "$preset" in
 		1)	preset="ultrafast" ;;

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -93,8 +93,8 @@ Backup_utility()
 		backupDir="$promptDir"
 		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 20 "1-20"
 		maxBackupNumber=$promptNum
-		Set_var backupDir "backupDir" "$sourceFile" str
-		Set_var maxBackupNumber "maxBackupNumber" "$sourceFile" str
+		Set_var backupDir "$backupDir" "$sourceFile" str
+		Set_var maxBackupNumber "$maxBackupNumber" "$sourceFile" str
 		systemctl enable --now jellyfin-backup.timer
 	fi
 

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -85,6 +85,7 @@ Backup_utility()
 	Has_sudo
 	source $sourceFile
 	optionNumber=
+	autoBackupSwitch=
 
 	if [[ ! -d $backupDir ]]; then
 		Prompt_user dir "> Please enter your desired directory for backup archives"
@@ -94,8 +95,17 @@ Backup_utility()
 		Set_var backupDir "$backupDir" "$sourceFile" str
 		Set_var maxBackupNumber "$maxBackupNumber" "$sourceFile" str
 		systemctl enable --now jellyfin-backup.timer
+		Set_var autoBackups true "$sourceFile" str
 	fi
-
+	
+	if $autoBackups; then
+		autoBackupSwitch="ON"
+	else
+		autoBackupSwitch="OFF"
+	fi
+	echo
+	echo "> Automatic backups are $autoBackupSwitch"
+	echo
 	echo "> 1. Enable automatic backups"
 	echo "> 2. Disable automatic backups"
 	echo "> 3. Change backup folder"
@@ -109,10 +119,12 @@ Backup_utility()
 	if [[ $optionNumber == 1 ]]; then
 		# enable auto-backups
 		systemctl enable --now jellyfin-backup.timer
+		Set_var autoBackups true "$sourceFile" str
 
 	elif [[ $optionNumber == 2 ]]; then
 		# disable auto-backups
 		systemctl disable --now jellyfin-backup.timer
+		Set_var autoBackups false "$sourceFile" str
 	
 	elif [[ $optionNumber == 3 ]]; then
 		# change backup folder
@@ -356,10 +368,22 @@ Import()
 
 		tar xf $importTar -C /
 		source $sourceFile
+		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/
 		mv -f /opt/jellyfin/backup/jellyfin-backup.timer $jellyfinServiceLocation/
 		systemctl daemon-reload
-		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
+		if [[ -n $autoBackups ]] && $autoBackups; then
+			systemctl enable --now jellyfin-backup.timer
+		else
+			if Prompt_user Yn "Enable automatic backups?" 0 0 "Y/n"; then
+				systemctl enable --now jellyfin-backup.timer
+				Set_var autoBackups true "$sourceFile" str
+			else
+				systemctl enable --now jellyfin-backup.timer
+				Set_var autoBackups false "$sourceFile" str
+			fi
+		fi
+		
 		if id "$defaultUser" &>/dev/null; then 
 			chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 			chmod -Rf 770 /opt/jellyfin

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -849,11 +849,16 @@ Uninstall()
 			echo "|          ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!          |"
 			echo "|-------------------------------------------------------------------|"
 		fi
+		echo "> Disabling and stopping Jellyfin..."
 		jellyman -d -S
 		systemctl disable --now jellyfin-backup.timer
+		echo "> Deleting /etc/jellyfin.conf and $jellyfinServiceLocation/jellyfin.service..."
 		rm -fv /etc/jellyfin.conf $jellyfinServiceLocation/jellyfin*
-		rm -rfv /opt/jellyfin
+		echo "> Deleting LINUX user $defaultUser"
 		userdel -f $defaultUser
+		echo "> Deleting the /opt/jellyfin directory..."
+		rm -rf /opt/jellyfin
+		echo "> Deleting Jellyman..."
 		rm -fv /usr/bin/base_functions.sh /usr/bin/jellyman
 	else
 		echo "> Phew! That was a close one!"

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -19,8 +19,6 @@ Backup()
 	if [[ ! -d /opt/jellyfin/backup ]]; then
 		mkdir /opt/jellyfin/backup
 	fi
-	cp /usr/bin/jellyman /opt/jellyfin/backup/
-	cp /usr/bin/base_functions.sh /opt/jellyfin/backup/
 	cp /etc/jellyfin.conf /opt/jellyfin/backup/
 	cp $jellyfinServiceLocation/jellyfin* /opt/jellyfin/backup/
 	

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -352,7 +352,7 @@ Import()
 		echo "> IMPORTING $importTar"
 		jellyman -S
 		rm -rf /opt/jellyfin
-		tar xvf $importTar -C /
+		tar xf $importTar -C /
 		clear
 		source $sourceFile
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/
@@ -363,6 +363,7 @@ Import()
 			chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
 			chmod -Rfv 770 /opt/jellyfin
 			jellyman -e -s
+			echo "> IMPORT COMPLETE!"
 		else
 			clear
 			echo "+-----------------------------------------------------------------------------------------------+"

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -14,7 +14,7 @@ Backup()
 	# Backup /opt/jellyfin to passed directory
 	backupDirectory="$1"
 	tarPath=
-	_date=$(date +%m%d%Y%H%M)
+	_date=$(date +%m-%d-%Y-%H:%M)
 	fileName=jellyfin-backup-$_date.tar
 	if [[ ! -d /opt/jellyfin/backup ]]; then
 		mkdir /opt/jellyfin/backup

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -361,7 +361,7 @@ Import()
 		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
 		if id "$defaultUser" &>/dev/null; then 
 			chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-			chmod -Rfv 770 /opt/jellyfin
+			chmod -Rf 770 /opt/jellyfin
 			jellyman -e -s
 			echo "> IMPORT COMPLETE!"
 		else
@@ -378,8 +378,8 @@ Import()
 			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
 				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
-				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-				chmod -Rfv 770 /opt/jellyfin
+				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rf 770 /opt/jellyfin
 				jellyman -s -t
 			else
 				Prompt_user usr "> Please enter a new LINUX user." 0 0 "jellyfin"
@@ -394,8 +394,8 @@ Import()
 				echo "> Linux user = $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
 				
-				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-				chmod -Rfv 770 /opt/jellyfin
+				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rf 770 /opt/jellyfin
 				jellyman -e -s -t
 			fi
 		fi
@@ -518,9 +518,9 @@ Permissions()
 		directoryToFix=$1
 		echo "> Setting permissions for "$directoryToFix""
 		time $(
-			chown -R $defaultUser:$defaultUser "$directoryToFix"
-			chmod -R 770 "$directoryToFix"
-			chmod -R ug+X "$directoryToFix"
+			chown -Rf $defaultUser:$defaultUser "$directoryToFix"
+			chmod -Rf 770 "$directoryToFix"
+			chmod -Rf ug+X "$directoryToFix"
 		)
 		echo "> ...DONE"
 	elif [[ ! -d "$1" ]] && [[ -n "$1" ]]; then
@@ -538,9 +538,9 @@ Permissions()
 
 		echo "> Setting permissions for ${defaultPath[*]}"
 		time $(
-			chown -R $defaultUser:$defaultUser ${defaultPath[*]}
-			chmod -R 770 ${defaultPath[*]}
-			chmod -R ug+X ${defaultPath[*]}
+			chown -Rf $defaultUser:$defaultUser ${defaultPath[*]}
+			chmod -Rf 770 ${defaultPath[*]}
+			chmod -Rf ug+X ${defaultPath[*]}
 		)
 		echo "> ...DONE"
 	fi
@@ -810,8 +810,8 @@ Rename_tv()
 				#echo "$extensionOfFile"
 				echo "> New Name:"
 				echo "> $newItemName"
-				chown -fv $defaultUser:$defaultUser "$newItemName"
-				chmod -fv 770 "$newItemName"
+				chown -f $defaultUser:$defaultUser "$newItemName"
+				chmod -f 770 "$newItemName"
 				echo
 			fi
 	done

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -832,7 +832,7 @@ Uninstall()
 		echo "> Goodbye..."
 		echo "> Removing Jellyfin and Jellyman in:"
 		Countdown 5
-			echo "> Blocking port 8096 and 8920..."
+		echo "> Blocking ports 8096 and 8920..."
 		if [ -x "$(command -v ufw)" ]; then
 			ufw deny $httpPort/tcp
 			ufw deny $httpsPort/tcp
@@ -849,17 +849,18 @@ Uninstall()
 			echo "|          ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!          |"
 			echo "|-------------------------------------------------------------------|"
 		fi
+		
 		echo "> Disabling and stopping Jellyfin..."
 		jellyman -d -S
 		systemctl disable --now jellyfin-backup.timer
 		echo "> Deleting /etc/jellyfin.conf and $jellyfinServiceLocation/jellyfin.service..."
-		rm -fv /etc/jellyfin.conf $jellyfinServiceLocation/jellyfin*
+		rm -f /etc/jellyfin.conf $jellyfinServiceLocation/jellyfin*
 		echo "> Deleting LINUX user $defaultUser"
 		userdel -f $defaultUser
 		echo "> Deleting the /opt/jellyfin directory..."
 		rm -rf /opt/jellyfin
 		echo "> Deleting Jellyman..."
-		rm -fv /usr/bin/base_functions.sh /usr/bin/jellyman
+		rm -f /usr/bin/base_functions.sh /usr/bin/jellyman
 	else
 		echo "> Phew! That was a close one!"
 	fi

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -349,7 +349,11 @@ Import()
 	if Prompt_user yN "> Import $importTar?"; then
 		echo "> IMPORTING $importTar"
 		jellyman -S
-		rm -rf /opt/jellyfin
+
+		if [[ -d /opt/jellyfin ]]; then
+			rm -rf /opt/jellyfin
+		fi
+
 		tar xf $importTar -C /
 		source $sourceFile
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -277,7 +277,7 @@ Version_switch()
 	jellyman -S
 	unlink /opt/jellyfin/jellyfin
 	ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
-	chown -Rfv $defaultUser:$defaultUser /opt/jellyfin/jellyfin
+	chown -Rf $defaultUser:$defaultUser /opt/jellyfin/jellyfin
 	Set_var currentVersion $newVersion "$sourceFile"
 	jellyman -s
 }
@@ -360,7 +360,7 @@ Import()
 		systemctl daemon-reload
 		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
 		if id "$defaultUser" &>/dev/null; then 
-			chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
+			chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 			chmod -Rf 770 /opt/jellyfin
 			jellyman -e -s
 			echo "> IMPORT COMPLETE!"

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -375,13 +375,12 @@ Import()
 			echo "|                   You may want to see who owns that configuration file with:                  |"
 			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
 			echo "+-----------------------------------------------------------------------------------------------+"
-			sleep 5
 			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
 				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
-				jellyman -s -t
+				jellyman -e -s -t
 			else
 				Prompt_user usr "> Please enter a new LINUX user." 0 0 "jellyfin"
 				defaultUser=$promptUsr

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -21,15 +21,15 @@ Backup()
 	cp /usr/bin/base_functions.sh /opt/jellyfin/backup/
 	cp /etc/jellyfin.conf /opt/jellyfin/backup/
 	cp $jellyfinServiceLocation/jellyfin* /opt/jellyfin/backup/
+	
 	if [[ $(echo "${backupDirectory: -1}") == "/" ]]; then
 		tarPath="$backupDirectory$fileName"
-		echo "$tarPath"
 	else
 		tarPath="$backupDirectory/$fileName"
-		echo "$tarPath"
 	fi
 
-	echo "Running backup, this may take some time..."
+	echo "$tarPath"
+	echo "> Running backup, this may take some time..."
 	time tar cf "$tarPath" /opt/jellyfin
 	USER1=$(stat -c '%U' "$backupDirectory")
 	chown -f $USER1:$USER1 "$tarPath"
@@ -43,9 +43,9 @@ Backup()
 	echo "|           sudo ./setup.sh and choose option 3          |"
 	echo "+--------------------------------------------------------+"
 	echo
-	echo "Your backup is:"
+	echo "> Your backup is:"
 	tarSize=$(du -h "$tarPath")
-	echo "Size: $tarSize"
+	echo "> Size: $tarSize"
 	return 0
 	exit
 }
@@ -55,7 +55,7 @@ Backup_auto()
 	Has_sudo
 	source $sourceFile
 	if [[ ! -n $backupDir ]]; then
-		echo "ERROR: AUTO-BACKUPS HAVE NOT BEEN SETUP. PLEASE RUN 'jellyman -bu'"
+		echo "> ERROR: AUTO-BACKUPS HAVE NOT BEEN SETUP. PLEASE RUN 'jellyman -bu'"
 		exit
 	else
 		jellyman -b "$backupDir"
@@ -67,10 +67,10 @@ Backup_auto()
 		tarCount=$(echo "$tarList" | wc -l)
 
 		while [[ $tarCount -gt $maxBackupNumber ]]; do
-			echo "There are $tarCount backups."
-			echo "Since there are more than $maxBackupNumber backups..."
-			echo "Jellyman is removing $oldestTar"
-			# echo "NewBackup=$newestTar"
+			echo "> There are $tarCount backups."
+			echo "> Since there are more than $maxBackupNumber backups..."
+			echo "> Jellyman is removing $oldestTar"
+			# echo "> NewBackup=$newestTar"
 			rm -f "$oldestTar"
 			tarList=$(ls -1 "$backupDir"/*.tar)
 			newestTar=$(echo "$tarList" | tail -n 1)
@@ -87,22 +87,22 @@ Backup_utility()
 	optionNumber=
 
 	if [[ ! -d $backupDir ]]; then
-		Prompt_user dir "Please enter your desired directory for backup archives"
+		Prompt_user dir "> Please enter your desired directory for backup archives"
 		backupDir="$promptDir"
-		Prompt_user num "Please enter your desired maximum number of backup archives" 1 20
+		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 20
 		maxBackupNumber=$promptNum
 		Set_var backupDir "backupDir" "$sourceFile" str
 		Set_var maxBackupNumber "maxBackupNumber" "$sourceFile" str
 		systemctl enable --now jellyfin-backup.timer
 	fi
 
-	echo "1. Enable automatic backups"
-	echo "2. Disable automatic backups"
-	echo "3. Change backup folder"
-	echo "4. Change max backups"
-	echo "5. Change frequency of backups"
+	echo "> 1. Enable automatic backups"
+	echo "> 2. Disable automatic backups"
+	echo "> 3. Change backup folder"
+	echo "> 4. Change max backups"
+	echo "> 5. Change frequency of backups"
 	echo
-	Prompt_user num "Please select the number corresponding with the option you want to select." 1 5
+	Prompt_user num "> Please select the number corresponding with the option you want to select." 1 5
 	optionNumber=$promptNum
 	echo
 	
@@ -116,36 +116,36 @@ Backup_utility()
 	
 	elif [[ $optionNumber == 3 ]]; then
 		# change backup folder
-		Prompt_user dir "Please enter your desired directory for backup archives"
+		Prompt_user dir "> Please enter your desired directory for backup archives"
 		backupDir="$promptDir"
 		Set_var "backupDir" "$backupDir" "$sourceFile"
 
 	elif [[ $optionNumber == 4 ]]; then
 		# change max backups
-		Prompt_user num "Please enter your desired maximum number of backup archives" 1 50
+		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 50
 		maxBackupNumber=$promptNum
 		Set_var "maxBackupNumber" "$maxBackupNumber" "$sourceFile"
 	
 	else
 		# change frequency of backups
-		echo "1. Daily backups"
-		echo "2. Weekly backups"
-		echo "3. Monthly backups"
+		echo "> 1. Daily backups"
+		echo "> 2. Weekly backups"
+		echo "> 3. Monthly backups"
 		echo
-		Prompt_user num "Please select the number corresponding with the option you want to select." 1 3
+		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3
 		_optionNumber=$promptNum
 		echo
 	
 		jellyfinBackupTimer=/usr/lib/systemd/system/jellyfin-backup.timer
 		if [[ $_optionNumber == 1 ]]; then
 			sed -i "s|OnCalendar.*|OnCalendar=*-*-* 01:00:00|g" $jellyfinBackupTimer
-			echo "Backups will now be created every day at 1:00 AM"
+			echo "> Backups will now be created every day at 1:00 AM"
 		elif [[ $_optionNumber == 2 ]]; then
 			sed -i "s|OnCalendar.*|OnCalendar=Sun *-*-* 01:00:00|g" $jellyfinBackupTimer
-			echo "Backups will now be created every Sunday at 1:00 AM"
+			echo "> Backups will now be created every Sunday at 1:00 AM"
 		elif [[ $_optionNumber == 3 ]]; then
 			sed -i "s|OnCalendar.*|OnCalendar=*-*-01 01:00:00|g" $jellyfinBackupTimer
-			echo "Backups will now be created on the 1st of every month at 1:00 AM"
+			echo "> Backups will now be created on the 1st of every month at 1:00 AM"
 		fi
 		
 		systemctl daemon-reload
@@ -158,11 +158,11 @@ isCurrentVersion()
 	source $sourceFile
 	jellyfinVersionToDownload=$1
 	if [[ $jellyfinVersionToDownload == $currentVersion ]]; then
-		echo "The installed version of Jellyfin matches the newest version available."
-		echo "Current Jellyfin version installed: $currentVersion"
+		echo "> The installed version of Jellyfin matches the newest version available."
+		echo "> Current Jellyfin version installed: $currentVersion"
 		return 0
 	else
-		echo "Newer Jellyfin version found..."
+		echo "> Newer Jellyfin version found..."
 		return 1
 	fi
 }
@@ -172,8 +172,8 @@ isInstalledVersion()
 	jellyfinVersionToDownload=$1
 	
 	if [ -d /opt/jellyfin/$jellyfinVersionToDownload ]; then
-		echo "The version to download matches an already installed version."
-		echo "Please use 'jellyman -vs' to switch Jellyfin versions."
+		echo "> The version to download matches an already installed version."
+		echo "> Please use 'jellyman -vs' to switch Jellyfin versions."
 		return 0
 	else
 		return 1
@@ -192,7 +192,7 @@ Check_disk_free()
 		echo "|    WILL RESET PERMISSIONS OF THE ENTERED      |"
 		echo "|       DIRECTORY TO YOUR JELLYFIN USER         |"
 		echo "+-----------------------------------------------+"
-		Prompt_user dir "Enter a valid directory"
+		Prompt_user dir "> Enter a valid directory"
 		defaultPath="$promptDir"
 		defaultPath=($defaultPath)
 		Set_var defaultPath $defaultPath "$sourceFile" array
@@ -228,15 +228,15 @@ Download_version()
 	warning=""
 
 	clear
-	echo "**WARNING** If Jellyfin v10.9.0 or later has been installed, it is impossible to revert to older versions as they will no longer be supported by Jellyman"
-	echo "Current Jellyfin version installed"
-	echo "$currentVersion"
+	echo "> **WARNING** If Jellyfin v10.9.0 or later has been installed, it is impossible to revert to older versions as they will no longer be supported by Jellyman"
+	echo "> Current Jellyfin version installed"
+	echo "> $currentVersion"
 	echo
-	echo "Please select a stable version:"
+	echo "> Please select a stable version:"
 	echo $warning
-	echo "$versionListNumbered"
-	echo "Please enter the number corresponding with"
-	Prompt_user num "the version you want to install" 1 $maxNumber
+	echo "> $versionListNumbered"
+	echo "> Please enter the number corresponding with"
+	Prompt_user num "  the version you want to install" 1 $maxNumber
 	versionToSwitchNumber=$promptNum
 	newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1)
 
@@ -246,7 +246,7 @@ Download_version()
 	else
 		newVersionNumberNoLetters=$(echo "$newVersionNumber" | sed -r "s|v||g")
 		newVersionHyphen=$(echo "$newVersionNumberNoLetters"-)
-		echo "https://repo.jellyfin.org/files/server/linux/stable/$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz"
+		echo "> https://repo.jellyfin.org/files/server/linux/stable/$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz"
 		jellyman -u "https://repo.jellyfin.org/files/server/linux/stable/$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz"
 	fi
 }
@@ -262,14 +262,14 @@ Version_switch()
 	warning=
 
 	clear
-	echo "Current Jellyfin version installed"
-	echo "$currentVersion"
+	echo "> Current Jellyfin version installed"
+	echo "> $currentVersion"
 	echo
-	echo "Jellyfin versions already downloaded:"
-	echo "$installedVersionsClean" | cat -n
-	echo "$warning"
-	echo "Please enter the number corresponding with"
-	Prompt_user num "the version you want to install" 1 $maxNumber
+	echo "> Jellyfin versions already downloaded:"
+	echo "> $installedVersionsClean" | cat -n
+	echo "> $warning"
+	echo "> Please enter the number corresponding with"
+	Prompt_user num "  the version you want to install" 1 $maxNumber
 	versionToSwitchNumber=$promptNum
 	newVersion=$(echo "$installedVersions" | head -n $versionToSwitchNumber | tail -n 1)
 	jellyman -S
@@ -291,15 +291,15 @@ Remove_version()
 	warning=
 
 	clear
-	echo "Current Jellyfin version installed"
-	echo "$currentVersion"
+	echo "> Current Jellyfin version installed"
+	echo "> $currentVersion"
 	echo
-	echo "Jellyfin versions already downloaded:"
+	echo "> Jellyfin versions already downloaded:"
 	echo "$installedVersions" | cat -n
 	echo
-	echo "$warning"
-	echo "Please enter the number corresponding with"
-	Prompt_user num "the version you want to ERASE" 1 $maxNumber
+	echo "> $warning"
+	echo "> Please enter the number corresponding with"
+	Prompt_user num "  the version you want to ERASE" 1 $maxNumber
 	versionToSwitchNumber=$promptNum
 	versionToRemove=$(echo "$installedVersions" | head -n $versionToRemoveNumber | tail -n 1)
 	warning="ERROR: Please select one of the numbers provided!"
@@ -310,7 +310,7 @@ before removing $versionToRemove"
 		versionToRemoveNumber=0
 	fi
 
-	echo "Removing /opt/jellyfin/$versionToRemove"
+	echo "> Removing /opt/jellyfin/$versionToRemove"
 	Countdown 5
 	rm -rfv /opt/jellyfin/$versionToRemove
 }
@@ -321,7 +321,7 @@ Import()
 	source $sourceFile
 	importTar=$1
 	
-	Prompt_user file "Please enter the path to the jellyfin-backup.tar archive."
+	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive."
 	importTar=$promptFile
 	echo
 	echo "+--------------------------------------------------------------------+"
@@ -329,8 +329,8 @@ Import()
 	echo "|      This import procedurewill erase /opt/jellyfin COMPLETELY      |"
 	echo "+--------------------------------------------------------------------+"
 
-	if Prompt_user yN "Import $importTar?"; then
-		echo "IMPORTING $importTar"
+	if Prompt_user yN "> Import $importTar?"; then
+		echo "> IMPORTING $importTar"
 		jellyman -S
 		rm -rf /opt/jellyfin
 		tar xvf $importTar -C /
@@ -355,23 +355,23 @@ Import()
 			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
 			echo "+-----------------------------------------------------------------------------------------------+"
 			sleep 5
-			if Prompt_user yN "Would you like to create the LINUX user $defaultUser?"; then
-				echo "Great!"
+			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
+				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rfv 770 /opt/jellyfin
 				jellyman -s -t
 			else
-				Prompt_user usr "Please enter a new LINUX user."
+				Prompt_user usr "> Please enter a new LINUX user."
 				defaultUser=$promptUsr
 				while id "$defaultUser" &>/dev/null; do
-					echo "Cannot create $defaultUser as $defaultUser already exists..."
-					Prompt_user usr "Please re-enter a new default Linux user for Jellyfin"
+					echo "> Cannot create $defaultUser as $defaultUser already exists..."
+					Prompt_user usr "> Please re-enter a new default Linux user for Jellyfin"
 					defaultUser=$promptUsr
 				 done
 		 
 				defaultUser=${defaultUser,,}
-				echo "Linux user = $defaultUser"
+				echo "> Linux user = $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
 				
 				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
@@ -380,7 +380,7 @@ Import()
 			fi
 		fi
 	else
-		echo "Returning..."
+		echo "> Returning..."
 		return 0
 		exit
 	fi
@@ -397,12 +397,12 @@ Library_scan()
 Import_api_key()
 {
 	Has_sudo
-	echo "Create a API key by signing into Jellyfin, going to Dashboard, then"
-	echo "clicking on API Keys under the Advanced section on the left."
+	echo "> Create a API key by signing into Jellyfin, going to Dashboard, then"
+	echo "> clicking on API Keys under the Advanced section on the left."
 	echo
-	Prompt_user str "Please paste your API Key"
+	Prompt_user str "> Please paste your API Key"
 	newAPIKey=$promptStr
-	echo "Logging new api key."
+	echo "> Logging new api key."
 	Set_var apiKey $newAPIKey "$sourceFile"
 }
 
@@ -411,8 +411,7 @@ Check_api_key()
 	Has_sudo
 	source $sourceFile
 	if [[ ! -n $apiKey ]]; then
-		echo "***ERROR***"
-		echo "ERROR: NO API KEY FOUND, RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
+		echo "> ERROR: NO API KEY FOUND, RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
 		return 1
 		exit
 	else
@@ -425,9 +424,9 @@ Http_port_change()
 	Has_sudo
 	source $sourceFile
 	echo
-	echo "Default http port is 8096"
+	echo "> Default http port is 8096"
 	if Is_jellyfin_setup; then
-		Prompt_user num "Please enter the new http network port for Jellyfin" 1 100000
+		Prompt_user num "> Please enter the new http network port for Jellyfin" 1 100000
 		port=$promptNum
 		oldPort=$httpPort
 		Set_var httpPort $port "$sourceFile"
@@ -435,8 +434,8 @@ Http_port_change()
 		Set_xml_var InternalHttpPort "$port" "/opt/jellyfin/config/network.xml"
 		Set_xml_var PublicHttpPort "$port" "/opt/jellyfin/config/network.xml"
 		jellyman -s
-		echo "Unblocking port $port"
-		echo "Blocking previous port $oldPort"
+		echo "> Unblocking port $port"
+		echo "> Blocking previous port $oldPort"
 		if [ -x "$(command -v ufw)" ]; then
 			ufw allow $port
 			ufw deny $oldPort
@@ -446,7 +445,8 @@ Http_port_change()
 			firewall-cmd --permanent --remove-port=$oldPort/tcp
 			firewall-cmd --reload
 		else
-			echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
+			echo "> ERROR: FAILED TO OPEN PORT $port!"
+			echo "> REASON: NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!"
 		fi
 	else
 		exit
@@ -458,8 +458,8 @@ Https_port_change()
 	Has_sudo
 	source $sourceFile
 	if Is_jellyfin_setup; then
-		echo "Default https port is 8920"
-		Prompt_user num "Please enter the new https network port for Jellyfin" 1 100000
+		echo "> Default https port is 8920"
+		Prompt_user num "> Please enter the new https network port for Jellyfin" 1 100000
 		port=$promptNum
 		oldPort=$httpsPort
 		Set_var httpsPort $port "$sourceFile"
@@ -467,8 +467,8 @@ Https_port_change()
 		Set_xml_var InternalHttpsPort "$port" "/opt/jellyfin/config/network.xml"
 		Set_xml_var PublicHttpsPort "$port" "/opt/jellyfin/config/network.xml"
 		jellyman -s
-		echo "Unblocking port $port"
-		echo "Blocking previous port $oldPort"
+		echo "> Unblocking port $port"
+		echo "> Blocking previous port $oldPort"
 		if [ -x "$(command -v ufw)" ]; then
 			ufw allow $port
 			ufw deny $oldPort
@@ -478,7 +478,8 @@ Https_port_change()
 			firewall-cmd --permanent --remove-port=$oldPort/tcp
 			firewall-cmd --reload
 		else
-			echo "FAILED TO OPEN PORT $port! ERROR NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
+			echo "> ERROR: FAILED TO OPEN PORT $port!"
+			echo "> REASON: NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
 		fi
 	else
 		exit
@@ -495,33 +496,33 @@ Permissions()
 
 	if [[ -d "$1" ]]; then
 		directoryToFix=$1
-		echo "Setting permissions for "$directoryToFix""
+		echo "> Setting permissions for "$directoryToFix""
 		time $(
 			chown -R $defaultUser:$defaultUser "$directoryToFix"
 			chmod -R 770 "$directoryToFix"
 			chmod -R ug+X "$directoryToFix"
 		)
-		echo "...DONE"
+		echo "> ...DONE"
 	elif [[ ! -d "$1" ]] && [[ -n "$1" ]]; then
-		echo "$1 is not a directory. Please enter a absolute path to your media"
-		echo "EXITING..."
+		echo "> $1 is not a directory. Please enter a absolute path to your media"
+		echo "> EXITING..."
 		exit
 	else
 		#Check if there is a recorded media library path for chown and chmod:
 		if ! areDirectories "${defaultPath[*]}"; then
-			echo "No default media directory found..."
-			echo "Running sudo jellyman -md to change media directory in:"
+			echo "> No default media directory found..."
+			echo "> Running sudo jellyman -md to change media directory in:"
 			Countdown 5
 			jellyman -md
 		fi
 
-		echo "Setting permissions for ${defaultPath[*]}"
+		echo "> Setting permissions for ${defaultPath[*]}"
 		time $(
 			chown -R $defaultUser:$defaultUser ${defaultPath[*]}
 			chmod -R 770 ${defaultPath[*]}
 			chmod -R ug+X ${defaultPath[*]}
 		)
-		echo "...DONE"
+		echo "> ...DONE"
 	fi
 }
 
@@ -546,7 +547,7 @@ Update()
 	newJellyfinArchive=""
 	
 	if [[ $1 == *"://"* ]] ; then 
-		echo "Fetching custom Jellyfin version..."
+		echo "> Fetching custom Jellyfin version..."
 		customVersionLink=$1
 		customVersion=$(echo $customVersionLink | rev | cut -d/ -f1 | rev)
 		jellyfin_archive=$customVersion
@@ -559,7 +560,7 @@ Update()
 		fi
 		
 		if [[ $fileType != "$architecture.tar.gz" ]]; then
-			echo "Supplied URL does not point to a $architecture.tar.gz.. EXITING..."
+			echo "> Supplied URL does not point to a $architecture.tar.gz.. EXITING..."
 			exit
 		fi
 	
@@ -567,16 +568,16 @@ Update()
 		wget -P /opt/jellyfin/update/ $customVersionLink
 	
 	else
-		echo "Getting current version from repository..."
+		echo "> Getting current version from repository..."
 		mkdir /opt/jellyfin/update
 		stableReleases=$(curl -sL https://repo.jellyfin.org/?path=/server/linux/latest-stable/$architecture/)
 		jellyfin_archive=$(echo "$stableReleases" | grep -Po jellyfin_[^_]+-$architecture.tar.gz | head -1)
 		jellyfin=$(echo "$jellyfin_archive" | sed -r "s|-$architecture.tar.gz||g")
 		newJellyfinArchive=$(echo "$jellyfin"-$architecture.tar.gz)
 		
-		echo "jellyfin_archive = $jellyfin_archive"
-		echo "jellyfin = $jellyfin"
-		echo "currentVersion = $currentVersion"
+		# echo "jellyfin_archive = $jellyfin_archive"
+		# echo "jellyfin = $jellyfin"
+		# echo "currentVersion = $currentVersion"
 		if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
 			wget -O /opt/jellyfin/update/$newJellyfinArchive https://repo.jellyfin.org/files/server/linux/latest-stable/$architecture/$jellyfin_archive
 		else
@@ -585,7 +586,7 @@ Update()
 	fi
 	
 	new_jellyfin_version=$(echo $jellyfin | sed -r 's/jellyfin_//g')
-	echo "Unpacking $jellyfin_archive to /opt/jellyfin/$jellyfin"
+	echo "> Unpacking $jellyfin_archive to /opt/jellyfin/$jellyfin"
 	jellyman -S
 	unlink /opt/jellyfin/jellyfin
 	tar xvzf /opt/jellyfin/update/$newJellyfinArchive -C /opt/jellyfin/
@@ -593,15 +594,15 @@ Update()
 	if [ -n "$(ls -A /opt/jellyfin/jellyfin/ 2>/dev/null)" ]; then
 			mv -f /opt/jellyfin/jellyfin /opt/jellyfin/$jellyfin
 	else
-			echo "Directory does not contain files..."
+			echo "> Directory does not contain files..."
 	fi
 
 	ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
-	echo "Removing $jellyfin_archive"
+	echo "> Removing $jellyfin_archive"
 	rm -rfv /opt/jellyfin/update
 
 	chown -R $defaultUser:$defaultUser /opt/jellyfin
-	echo "Jellyfin updated to version $new_jellyfin_version"
+	echo "> Jellyfin updated to version $new_jellyfin_version"
 	Set_var currentVersion $jellyfin "$sourceFile"
 	jellyman -s -t
 }
@@ -623,42 +624,40 @@ Update_beta()
 	warning=""
 	
 	if [[ ! $betasAvailable == .*"tar.gz".* ]]; then
-		echo "Sorry, no betas are available right now..."
+		echo "> Sorry, no betas are available right now..."
 		exit
 	fi
 
-	while (( $versionSelected > $maxNumber )) || (( $versionSelected < 1 )); do
-		clear
-		echo "Available betas:"
-		echo $warning
-		echo "$jellyfinNumbered"
-		echo "Select which version to install"
-		read -p ">>> [1-$maxNumber] : " versionSelected
-		Prompt_user num "Select which version to install" 1 $maxNumber
-		versionSelected=$promptNum
-		newVersionName=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1 | sed -r "s|-$architecture.tar.gz||g")
-		newVersionNumber=$(echo $newVersionName | sed -r 's/jellyfin_//g')
-		if isCurrentVersion $newVersionName || isInstalledVersion $newVersionName; then
-			warning="ERROR: That Jellyfin version is already installed!"
-			echo "Press CTRL+C to exit..."
-		else
-			newVersionArchive=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1)
-			echo "Getting $newVersionArchive..."
-			wget -O /opt/jellyfin/update/$newVersionName https://repo.jellyfin.org/files/server/linux/latest-unstable/$architecture/$newVersionArchive
-			echo "Unpacking $newVersionArchive to /opt/jellyfin/..."
-			tar xvzf /opt/jellyfin/update/$newVersionArchive -C /opt/jellyfin/
-			jellyman -S
-			unlink /opt/jellyfin/jellyfin
-			ln -s /opt/jellyfin/$newVersionName /opt/jellyfin/jellyfin
-			echo "Removing $newVersionArchive"
-			rm -rfv /opt/jellyfin/update
+	clear
+	echo "> Available betas:"
+	echo $warning
+	echo "$jellyfinNumbered"
+	echo
 
-			chown -R $defaultUser:$defaultUser /opt/jellyfin
-			echo "Jellyfin updated to version $newVersionNumber"
-			Set_var currentVersion $newVersionName "$sourceFile"
-			jellyman -s -t
-		fi
-	done
+	Prompt_user num "> Select which version to install" 1 $maxNumber
+	versionSelected=$promptNum
+	newVersionName=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1 | sed -r "s|-$architecture.tar.gz||g")
+	newVersionNumber=$(echo $newVersionName | sed -r 's/jellyfin_//g')
+	if isCurrentVersion $newVersionName || isInstalledVersion $newVersionName; then
+		warning="> ERROR: That Jellyfin version is already installed!"
+		echo "> Press CTRL+C to exit..."
+	else
+		newVersionArchive=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1)
+		echo "> Getting $newVersionArchive..."
+		wget -O /opt/jellyfin/update/$newVersionName https://repo.jellyfin.org/files/server/linux/latest-unstable/$architecture/$newVersionArchive
+		echo "> Unpacking $newVersionArchive to /opt/jellyfin/..."
+		tar xvzf /opt/jellyfin/update/$newVersionArchive -C /opt/jellyfin/
+		jellyman -S
+		unlink /opt/jellyfin/jellyfin
+		ln -s /opt/jellyfin/$newVersionName /opt/jellyfin/jellyfin
+		echo "> Removing $newVersionArchive"
+		rm -rfv /opt/jellyfin/update
+
+		chown -R $defaultUser:$defaultUser /opt/jellyfin
+		echo "> Jellyfin updated to version $newVersionNumber"
+		Set_var currentVersion $newVersionName "$sourceFile"
+		jellyman -s -t
+	fi
 }
 
 
@@ -693,7 +692,7 @@ Recertify_https()
 		rm -fv /opt/jellyfin/cert/*
 		openssl req -x509 -newkey rsa:4096 -keyout /opt/jellyfin/cert/privkey.pem -out /opt/jellyfin/cert/cert.pem -days 365 -nodes -subj '/CN=jellyfin.lan'
 		openssl pkcs12 -export -out /opt/jellyfin/cert/jellyfin.pfx -inkey /opt/jellyfin/cert/privkey.pem -in /opt/jellyfin/cert/cert.pem -passout pass:
-		echo "Enabling https..."
+		echo "> Enabling https..."
 		jellyman -S
 		Set_xml_var EnableHttps "true" "/opt/jellyfin/config/network.xml"
 		Set_xml_var CertificatePath "/opt/jellyfin/cert/jellyfin.pfx" "/opt/jellyfin/config/network.xml"
@@ -731,14 +730,14 @@ Rename_tv()
 		echo "|      NAMES ARE IN THE SAME LOCATION IN THE DIRECTORY         |"
 		echo "|--------------------------------------------------------------|"
 		echo
-		Prompt_user dir "Please enter a directory"
+		Prompt_user dir "> Please enter a directory"
 		directoryToCorrect=$promptDir
 		clear
 		nameOfTestFile=$(ls -1 $directoryToCorrect | head -1)
 		if [ -f "$nameOfTestFile" ]; then
 			loop=false
 		else
-			echo "Path does not exist, please try again."
+			echo "> Path does not exist, please try again."
 		fi
 	done
 	
@@ -753,17 +752,17 @@ Rename_tv()
 
 	while [ $number -lt $testDirCount ]; do
 		testName=$(echo $nameOfTestFile | cut -d "/" -f $iteration)
-		echo "$number : $testName"
+		echo "> $number : $testName"
 		iteration=$(($iteration + 1))
 		
 		number=$(($number + 1))	
 	done
 	
-	echo "Please enter the number that corresponds with the show's name above"
+	echo "> Please enter the number that corresponds with the show's name above"
 	read directoryNumber
 	directoryNumber=$(($directoryNumber + 1))
 	nameOfShow=$(dirname "$directoryToCorrect" | cut -d "/" -f $directoryNumber)
-	echo "You chose $nameOfShow"
+	echo "> You chose $nameOfShow"
 
 	for item in $directoryToCorrect
 	do
@@ -775,8 +774,8 @@ Rename_tv()
 				episodeNumber=$(echo "$item" | grep -oE '[sS][0-9][0-9][eE][0-9][0-9]')
 				mv "$item" "$nameOfDirectory/$nameOfShow $episodeNumber.$extensionOfFile"
 				newItemName="$nameOfDirectory/$nameOfShow $episodeNumber.$extensionOfFile"
-				echo "item:"
-				echo "$item"
+				echo "> item:"
+				echo "> $item"
 				#echo "Directory:"
 				#echo "$nameOfDirectory"
 				#echo "Name Of Show:"
@@ -785,8 +784,8 @@ Rename_tv()
 				#echo "$episodeNumber"
 				#echo "extension of file:"
 				#echo "$extensionOfFile"
-				echo "New Name:"
-				echo "$newItemName"
+				echo "> New Name:"
+				echo "> $newItemName"
 				chown -fv $defaultUser:$defaultUser "$newItemName"
 				chmod -fv 770 "$newItemName"
 				echo
@@ -806,11 +805,11 @@ Uninstall()
 	echo "|   and Jellyman, exceptthe Media Library and jellyfin-backup.tar   |"
 	echo "|-------------------------------------------------------------------|"
 	echo
-	if Prompt_user yN "CONTINUE?"; then
-		echo "Goodbye..."
-		echo "Removing Jellyfin and Jellyman in:"
+	if Prompt_user yN "> CONTINUE?"; then
+		echo "> Goodbye..."
+		echo "> Removing Jellyfin and Jellyman in:"
 		Countdown 5
-			echo "Blocking port 8096 and 8920..."
+			echo "> Blocking port 8096 and 8920..."
 		if [ -x "$(command -v ufw)" ]; then
 			ufw deny $httpPort/tcp
 			ufw deny $httpsPort/tcp
@@ -834,7 +833,7 @@ Uninstall()
 		userdel -f $defaultUser
 		rm -fv /usr/bin/base_functions.sh /usr/bin/jellyman
 	else
-		echo "Phew! That was a close one!"
+		echo "> Phew! That was a close one!"
 	fi
 }
 
@@ -874,15 +873,15 @@ Progress_bar()
 
 		printf "\rTranscoded : [$currentState/$totalState] [${_fill// /#}${_empty// /-}] ${_progress}%%"
 		printf "\nTranscoding File : $previousVideo \n"
-		echo "Original Size    : $previousVideoSizeMB MB"
-		echo "New Size         : $currentVideoSizeMB MB"
-		echo "Percentave Saved : $sizeSavingsPercent"
+		echo "> Original Size    : $previousVideoSizeMB MB"
+		echo "> New Size         : $currentVideoSizeMB MB"
+		echo "> Percentave Saved : $sizeSavingsPercent"
 
 		if [ $currentState -eq $totalState ]; then
 			printf '\nFinished!\n'
 		fi
 	else
-		echo "loading..."
+		echo "> loading..."
 	fi
 }
 
@@ -892,8 +891,8 @@ View_Transcode_Progress()
 		clear
 		Progress_bar
 		echo
-		echo "CTRL+C to exit progress bar"
-		echo "'jellyman -tcp' to bring back Transcode Progress"
+		echo "> CTRL+C to exit progress bar"
+		echo "> 'jellyman -tcp' to bring back Transcode Progress"
 		sleep 3
 	done
 }
@@ -917,18 +916,18 @@ Qualify_Transcode()
 		fi
 		_videoRatio=$(bc -l <<< "$_videoSizeGB/$_videoTimeHours")
 		if [ 1 -eq "$(echo "$_videoRatio > $desiredGBperHour" | bc)" ]; then
-			echo "Transcoding $videoToEdit ..."
+			echo "> Transcoding $videoToEdit ..."
 			_newName=$(echo $videoToEdit | rev | cut -d "." -f 2 | rev)
-			echo "Video time in Hours: $_videoTimeHours"
-			echo "Video size GB: $_videoSizeGB"
-			echo "Current GB/Hour: $_videoRatio"
+			echo "> Video time in Hours: $_videoTimeHours"
+			echo "> Video size GB: $_videoSizeGB"
+			echo "> Current GB/Hour: $_videoRatio"
 			echo "$videoToEdit" >> $qualifiedVideos
 		else
-			echo "$videoToEdit is less than $desiredGBperHour GB/Hour, skipping..."
+			echo "> $videoToEdit is less than $desiredGBperHour GB/Hour, skipping..."
 		fi
 	else
 		_file=$(echo $videoToEdit | rev | cut -d "/" -f 1 | rev)
-		echo "$_file is not a video, skipping..."
+		echo "> $_file is not a video, skipping..."
 	fi
 }
 
@@ -966,12 +965,12 @@ Transcode_file()
 		Set_var currentVideo "$_newName.downsampled.mp4" "$progressBarConf" str
 		Set_var previousVideo "$currentVideo" "$progressBarConf" str
 
-		echo "Transcoding $currentVideo"
+		echo "> Transcoding $currentVideo"
 		nice ffmpeg -y -i "$currentVideo" -c:v libx265 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
 		_newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
-		echo "Downsampled size: $_newVideoSize"
+		echo "> Downsampled size: $_newVideoSize"
 		if $deleteOrNot; then
-			echo "DELETING $currentVideo IN: "
+			echo "> DELETING $currentVideo IN: "
 			Countdown 10
 			rm -v "$currentVideo"
 			mv -v "$_newName.downsampled.mp4" "$_newName.mp4"
@@ -1002,30 +1001,29 @@ Transcode()
 	echo "|        TO RUN THIS COMMAND IN 'screen' THEN PRESSING         |"
 	echo "|                       CTRL + A THEN D                        |"
 	echo "|--------------------------------------------------------------|"
-	Prompt_user dir "Please enter the path to the file(s)"
+	Prompt_user dir "> Please enter the path to the file(s)"
 	_directoryToCorrect=$promptDir
 	echo
-	echo "Please enter the desired GB per hour of video"
-	Prompt_user str "EXAMPLE: 1 OR 2.5"
+	echo "> Please enter the desired GB per hour of video"
+	Prompt_user str "> EXAMPLE: 1 OR 2.5"
 	desiredGBperHour=$promptStr
 	
 	preset=0
 	while [ $preset -gt 9 ] || [ $preset -lt 1 ]; do
 		clear
 		echo
-		echo "1: ultrafast"
-		echo "2: superfast"
-		echo "3: veryfast"
-		echo "4: faster"
-		echo "5: fast"
-		echo '6: medium (RECOMMENDED)'
-		echo "7: slow"
-		echo "8: slower"
-		echo "9: veryslow"
+		echo "> 1: ultrafast"
+		echo "> 2: superfast"
+		echo "> 3: veryfast"
+		echo "> 4: faster"
+		echo "> 5: fast"
+		echo '> 6: medium (RECOMMENDED)'
+		echo "> 7: slow"
+		echo "> 8: slower"
+		echo "> 9: veryslow"
 		echo
-		echo "Please choose a transcode preset"
-		read -p ">>> [1-9] : " preset
-		if [[ ! $preset == [1-9] ]]; then
+		Prompt_user num "> Please choose a transcode preset" 1 9
+		preset=$promptNum
 		 preset=0
 		fi
 	done
@@ -1044,12 +1042,12 @@ Transcode()
 	
 	crf=0
 	clear
-	echo 'Please enter a Constant Rate Factor (CRF) [20-30]'
-	echo "22-26 is recommended"
-	Prompt_user num "20 is better quality and 30 is lower quality" 20 30
+	echo '> Please enter a Constant Rate Factor (CRF) [20-30]'
+	echo "> 22-26 is recommended"
+	Prompt_user num "> 20 is better quality and 30 is lower quality" 20 30
 	crf=$promptNum
 	echo
-	if Prompt_user yN "Would you like to delete the original file(s) after transcode?"; then
+	if Prompt_user yN "> Would you like to delete the original file(s) after transcode?"; then
 		deleteOrNot=true
 	else
 		deleteOrNot=false
@@ -1071,10 +1069,10 @@ Update-jellyman()
 	jellymanManFile=$(curl -sL https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1)
 	currentJellymanVersion=$(echo $jellymanManFile | grep " - v" | cut -d "v" -f2 | cut -d " " -f1)
 	if [[ "v$currentJellymanVersion" == $jellymanVersion ]]; then
-		echo "Jellyman is up to date. No new versions available."
+		echo "> Jellyman is up to date. No new versions available."
 		exit
 	else
-		echo "Updating Jellyman - The Jellyfin Manager from $jellymanVersion to v$currentJellymanVersion"
+		echo "> Updating Jellyman - The Jellyfin Manager from $jellymanVersion to v$currentJellymanVersion"
 		git clone https://github.com/Smiley-McSmiles/jellyman
 		cd jellyman
 		chmod ug+x setup.sh
@@ -1222,13 +1220,13 @@ if [ -n "$1" ]; then
 			-X | --uninstall) Uninstall ;;
 			--dev_func) Dev_func "$2"
 									shift ;;
-			*) echo "Option $1 not recognized" 
+			*) echo "> ERROR: Option $1 not recognized" 
 				Help ;;
 		esac
 		shift
 	done
 else
-	echo "No commands found."
+	echo "> No commands found."
 	Help
 	exit
 fi

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -83,86 +83,111 @@ Backup_auto()
 Backup_utility()
 {
 	Has_sudo
-	source $sourceFile
-	optionNumber=
-	autoBackupSwitch=
+	while true; do
+		source $sourceFile
+		clear
+		optionNumber=
+		autoBackupSwitch=
 
-	if [[ ! -d $backupDir ]]; then
-		Prompt_user dir "> Please enter your desired directory for backup archives"
-		backupDir="$promptDir"
-		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 20 "1-20"
-		maxBackupNumber=$promptNum
-		Set_var backupDir "$backupDir" "$sourceFile" str
-		Set_var maxBackupNumber "$maxBackupNumber" "$sourceFile" str
-		systemctl enable --now jellyfin-backup.timer
-		Set_var autoBackups true "$sourceFile" str
-	fi
-	
-	if $autoBackups; then
-		autoBackupSwitch="ON"
-	else
-		autoBackupSwitch="OFF"
-	fi
-	echo
-	echo "> Automatic backups are $autoBackupSwitch"
-	echo
-	echo "> 1. Enable automatic backups"
-	echo "> 2. Disable automatic backups"
-	echo "> 3. Change backup folder"
-	echo "> 4. Change max backups"
-	echo "> 5. Change frequency of backups"
-	echo
-	Prompt_user num "> Please select the number corresponding with the option you want to select." 1 5 "1-5"
-	optionNumber=$promptNum
-	echo
-	
-	if [[ $optionNumber == 1 ]]; then
-		# enable auto-backups
-		systemctl enable --now jellyfin-backup.timer
-		Set_var autoBackups true "$sourceFile" str
-
-	elif [[ $optionNumber == 2 ]]; then
-		# disable auto-backups
-		systemctl disable --now jellyfin-backup.timer
-		Set_var autoBackups false "$sourceFile" str
-	
-	elif [[ $optionNumber == 3 ]]; then
-		# change backup folder
-		Prompt_user dir "> Please enter your desired directory for backup archives"
-		backupDir="$promptDir"
-		Set_var "backupDir" "$backupDir" "$sourceFile"
-
-	elif [[ $optionNumber == 4 ]]; then
-		# change max backups
-		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 50 "1-50"
-		maxBackupNumber=$promptNum
-		Set_var "maxBackupNumber" "$maxBackupNumber" "$sourceFile"
-	
-	else
-		# change frequency of backups
-		echo "> 1. Daily backups"
-		echo "> 2. Weekly backups"
-		echo "> 3. Monthly backups"
-		echo
-		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
-		_optionNumber=$promptNum
-		echo
-	
-		jellyfinBackupTimer=/usr/lib/systemd/system/jellyfin-backup.timer
-		if [[ $_optionNumber == 1 ]]; then
-			sed -i "s|OnCalendar.*|OnCalendar=*-*-* 01:00:00|g" $jellyfinBackupTimer
-			echo "> Backups will now be created every day at 1:00 AM"
-		elif [[ $_optionNumber == 2 ]]; then
-			sed -i "s|OnCalendar.*|OnCalendar=Sun *-*-* 01:00:00|g" $jellyfinBackupTimer
-			echo "> Backups will now be created every Sunday at 1:00 AM"
-		elif [[ $_optionNumber == 3 ]]; then
-			sed -i "s|OnCalendar.*|OnCalendar=*-*-01 01:00:00|g" $jellyfinBackupTimer
-			echo "> Backups will now be created on the 1st of every month at 1:00 AM"
+		if [[ ! -d $backupDir ]]; then
+			Prompt_user dir "> Please enter your desired directory for backup archives"
+			backupDir="$promptDir"
+			Prompt_user num "> Please enter your desired maximum number of backup archives" 1 20 "1-20"
+			maxBackupNumber=$promptNum
+			systemctl enable --now jellyfin-backup.timer
+			Set_var backupDir "$backupDir" "$sourceFile" str
+			Set_var maxBackupNumber 3 "$sourceFile" str
+			Set_var autoBackups true "$sourceFile" str
+			Set_var backupFrequency "weekly" "$sourceFile"
 		fi
 		
-		systemctl daemon-reload
-		systemctl restart jellyfin-backup.timer
-	fi
+		if $autoBackups; then
+			autoBackupSwitch="ON"
+		else
+			autoBackupSwitch="OFF"
+		fi
+		echo
+		echo "> Automatic backups are $autoBackupSwitch"
+		echo
+		echo "> 1. Enable automatic backups"
+		echo "> 2. Disable automatic backups"
+		echo "> 3. Change backup folder"
+		echo "> 4. Change max backups [ $maxBackupNumber ]"
+		echo "> 5. Change frequency of backups [ $backupFrequency ]"
+		echo "> 6. EXIT"
+		echo
+		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 6 "1-6"
+		optionNumber=$promptNum
+		echo
+		case $optionNumber in
+			"1")
+				# enable auto-backups
+				systemctl enable --now jellyfin-backup.timer
+				Set_var autoBackups true "$sourceFile" str
+				;;
+			"2")
+				# disable auto-backups
+				systemctl disable --now jellyfin-backup.timer
+				Set_var autoBackups false "$sourceFile" str
+				;;
+			"3")
+				# change backup folder
+				if [[ -n $backupDir ]]; then
+					echo "> Current directory for backups is $backupDir"
+				fi
+				Prompt_user dir "> Please enter your desired directory for backup archives"
+				backupDir="$promptDir"
+				Set_var "backupDir" "$backupDir" "$sourceFile"
+				;;
+			"4")
+				# change max backups
+				if [[ -n $maxBackupNumber ]]; then
+					echo "> Current maximum backups allowed is $maxBackupNumber"
+				fi
+				Prompt_user num "> Please enter your desired maximum number of backup archives" 1 50 "1-50"
+				maxBackupNumber=$promptNum
+				Set_var maxBackupNumber "$maxBackupNumber" "$sourceFile"
+				;;
+			"5")
+				# change frequency of backups
+				echo "> Automatic backups will be done on a $backupFrequency basis."
+				echo
+				echo "> 1. Daily backups"
+				echo "> 2. Weekly backups"
+				echo "> 3. Monthly backups"
+				echo
+				Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
+				_optionNumber=$promptNum
+				echo
+				jellyfinBackupTimer=/usr/lib/systemd/system/jellyfin-backup.timer
+				case $_optionNumber in
+					"1")
+						Set_var backupFrequency "daily" "$sourceFile"
+						sed -i "s|OnCalendar.*|OnCalendar=*-*-* 01:00:00|g" $jellyfinBackupTimer
+						echo "> Backups will now be created every day at 1:00 AM"
+						read -p "> Press ENTER to exit" ENTER
+						;;
+					"2")
+						Set_var backupFrequency "weekly" "$sourceFile"
+						sed -i "s|OnCalendar.*|OnCalendar=Sun *-*-* 01:00:00|g" $jellyfinBackupTimer
+						echo "> Backups will now be created every Sunday at 1:00 AM"
+						read -p "> Press ENTER to exit" ENTER
+						;;
+					"3")
+						Set_var backupFrequency "monthly" "$sourceFile"
+						sed -i "s|OnCalendar.*|OnCalendar=*-*-01 01:00:00|g" $jellyfinBackupTimer
+						echo "> Backups will now be created on the 1st of every month at 1:00 AM"
+						read -p "> Press ENTER to exit" ENTER
+						;;
+				esac
+				systemctl daemon-reload
+				systemctl restart jellyfin-backup.timer
+				;;
+			"6")
+				exit
+				;;
+		esac
+	done
 }
 
 isCurrentVersion()
@@ -378,9 +403,11 @@ Import()
 			if Prompt_user Yn "Enable automatic backups?" 0 0 "Y/n"; then
 				systemctl enable --now jellyfin-backup.timer
 				Set_var autoBackups true "$sourceFile" str
+				Set_var "backupFrequency" "weekly" "$sourceFile"
 			else
 				systemctl enable --now jellyfin-backup.timer
 				Set_var autoBackups false "$sourceFile" str
+				Set_var "backupFrequency" "weekly" "$sourceFile"
 			fi
 		fi
 		
@@ -1113,7 +1140,7 @@ Transcode()
 	View_Transcode_Progress
 }
 
-Update-jellyman()
+Update_jellyman()
 {
 	Has_sudo
 	jellymanManFile=$(curl -sL https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1)
@@ -1245,7 +1272,7 @@ if [ -n "$1" ]; then
 					 Update $2
 					 shift
 				 fi ;;
-			-U | --update-jellyman) Update-jellyman
+			-U | --update-jellyman) Update_jellyman
 				 exit ;;
 			-ub | --update-beta) Update_beta ;;
 			-v | --version) Get_jellyfin_version

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.7.6"
+jellymanVersion="v1.7.7"
 sourceFile="/opt/jellyfin/config/jellyman.conf"
 source /usr/bin/base_functions.sh
 
@@ -91,8 +91,8 @@ Backup_utility()
 		backupDir="$promptDir"
 		Prompt_user num "Please enter your desired maximum number of backup archives" 1 20
 		maxBackupNumber=$promptNum
-		echo "backupDir=$backupDir" >> $sourceFile
-		echo "maxBackupNumber=$maxBackupNumber" >> $sourceFile
+		Set_var backupDir "backupDir" "$sourceFile" str
+		Set_var maxBackupNumber "maxBackupNumber" "$sourceFile" str
 		systemctl enable --now jellyfin-backup.timer
 	fi
 
@@ -118,13 +118,13 @@ Backup_utility()
 		# change backup folder
 		Prompt_user dir "Please enter your desired directory for backup archives"
 		backupDir="$promptDir"
-		Change_variable "backupDir" "$backupDir" "$sourceFile"
+		Set_var "backupDir" "$backupDir" "$sourceFile"
 
 	elif [[ $optionNumber == 4 ]]; then
 		# change max backups
 		Prompt_user num "Please enter your desired maximum number of backup archives" 1 50
 		maxBackupNumber=$promptNum
-		Change_variable "maxBackupNumber" "$maxBackupNumber" "$sourceFile"
+		Set_var "maxBackupNumber" "$maxBackupNumber" "$sourceFile"
 	
 	else
 		# change frequency of backups
@@ -195,7 +195,7 @@ Check_disk_free()
 		Prompt_user dir "Enter a valid directory"
 		defaultPath="$promptDir"
 		defaultPath=($defaultPath)
-		Change_variable defaultPath $defaultPath "$sourceFile" array
+		Set_var defaultPath $defaultPath "$sourceFile" array
 		df -h ${defaultPath[*]}
 	else 
 		df -h ${defaultPath[*]}
@@ -276,7 +276,7 @@ Version_switch()
 	unlink /opt/jellyfin/jellyfin
 	ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
 	chown -Rfv $defaultUser:$defaultUser /opt/jellyfin/jellyfin
-	Change_variable currentVersion $newVersion "$sourceFile"
+	Set_var currentVersion $newVersion "$sourceFile"
 	jellyman -s
 }
 
@@ -403,7 +403,7 @@ Import_api_key()
 	Prompt_user str "Please paste your API Key"
 	newAPIKey=$promptStr
 	echo "Logging new api key."
-	Change_variable apiKey $newAPIKey "$sourceFile"
+	Set_var apiKey $newAPIKey "$sourceFile"
 }
 
 Check_api_key()
@@ -412,7 +412,7 @@ Check_api_key()
 	source $sourceFile
 	if [[ ! -n $apiKey ]]; then
 		echo "***ERROR***"
-		echo "NO API KEY FOUND, RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
+		echo "ERROR: NO API KEY FOUND, RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
 		return 1
 		exit
 	else
@@ -430,10 +430,10 @@ Http_port_change()
 		Prompt_user num "Please enter the new http network port for Jellyfin" 1 100000
 		port=$promptNum
 		oldPort=$httpPort
-		Change_variable httpPort $port "$sourceFile"
+		Set_var httpPort $port "$sourceFile"
 		jellyman -S
-		Change_xml_variable InternalHttpPort "$port" "/opt/jellyfin/config/network.xml"
-		Change_xml_variable PublicHttpPort "$port" "/opt/jellyfin/config/network.xml"
+		Set_xml_var InternalHttpPort "$port" "/opt/jellyfin/config/network.xml"
+		Set_xml_var PublicHttpPort "$port" "/opt/jellyfin/config/network.xml"
 		jellyman -s
 		echo "Unblocking port $port"
 		echo "Blocking previous port $oldPort"
@@ -462,10 +462,10 @@ Https_port_change()
 		Prompt_user num "Please enter the new https network port for Jellyfin" 1 100000
 		port=$promptNum
 		oldPort=$httpsPort
-		Change_variable httpsPort $port "$sourceFile"
+		Set_var httpsPort $port "$sourceFile"
 		jellyman -S
-		Change_xml_variable InternalHttpsPort "$port" "/opt/jellyfin/config/network.xml"
-		Change_xml_variable PublicHttpsPort "$port" "/opt/jellyfin/config/network.xml"
+		Set_xml_var InternalHttpsPort "$port" "/opt/jellyfin/config/network.xml"
+		Set_xml_var PublicHttpsPort "$port" "/opt/jellyfin/config/network.xml"
 		jellyman -s
 		echo "Unblocking port $port"
 		echo "Blocking previous port $oldPort"
@@ -590,11 +590,10 @@ Update()
 	unlink /opt/jellyfin/jellyfin
 	tar xvzf /opt/jellyfin/update/$newJellyfinArchive -C /opt/jellyfin/
 	
-	if [ -n "$(ls -A /opt/jellyfin/jellyfin/ 2>/dev/null)" ]
-		then
-		  mv -f /opt/jellyfin/jellyfin /opt/jellyfin/$jellyfin
-		else
-		  echo "Directory does not contain files..."
+	if [ -n "$(ls -A /opt/jellyfin/jellyfin/ 2>/dev/null)" ]; then
+			mv -f /opt/jellyfin/jellyfin /opt/jellyfin/$jellyfin
+	else
+			echo "Directory does not contain files..."
 	fi
 
 	ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
@@ -603,7 +602,7 @@ Update()
 
 	chown -R $defaultUser:$defaultUser /opt/jellyfin
 	echo "Jellyfin updated to version $new_jellyfin_version"
-	Change_variable currentVersion $jellyfin "$sourceFile"
+	Set_var currentVersion $jellyfin "$sourceFile"
 	jellyman -s -t
 }
 
@@ -656,7 +655,7 @@ Update_beta()
 
 			chown -R $defaultUser:$defaultUser /opt/jellyfin
 			echo "Jellyfin updated to version $newVersionNumber"
-			Change_variable currentVersion $newVersionName "$sourceFile"
+			Set_var currentVersion $newVersionName "$sourceFile"
 			jellyman -s -t
 		fi
 	done
@@ -696,8 +695,8 @@ Recertify_https()
 		openssl pkcs12 -export -out /opt/jellyfin/cert/jellyfin.pfx -inkey /opt/jellyfin/cert/privkey.pem -in /opt/jellyfin/cert/cert.pem -passout pass:
 		echo "Enabling https..."
 		jellyman -S
-		Change_xml_variable EnableHttps "true" "/opt/jellyfin/config/network.xml"
-		Change_xml_variable CertificatePath "/opt/jellyfin/cert/jellyfin.pfx" "/opt/jellyfin/config/network.xml"
+		Set_xml_var EnableHttps "true" "/opt/jellyfin/config/network.xml"
+		Set_xml_var CertificatePath "/opt/jellyfin/cert/jellyfin.pfx" "/opt/jellyfin/config/network.xml"
 		chown -Rf $defaultUser:$defaultUser /opt/jellyfin/cert
 		chmod -Rf 770 /opt/jellyfin/cert
 		jellyman -s
@@ -921,7 +920,7 @@ Qualify_Transcode()
 			echo "Transcoding $videoToEdit ..."
 			_newName=$(echo $videoToEdit | rev | cut -d "." -f 2 | rev)
 			echo "Video time in Hours: $_videoTimeHours"
-			echo "Video size GB:  $_videoSizeGB"
+			echo "Video size GB: $_videoSizeGB"
 			echo "Current GB/Hour: $_videoRatio"
 			echo "$videoToEdit" >> $qualifiedVideos
 		else
@@ -962,21 +961,21 @@ Transcode_file()
 #		echo "$_progress" > $progressBarFile
 
 		echo '#!/bin/bash' > "$progressBarConf"
-		echo "startState=$_progressIteration" >> "$progressBarConf"
-		echo "maxState=$totalVideos" >> "$progressBarConf"
-		echo "currentVideo=\"$_newName.downsampled.mp4\"" >> "$progressBarConf"
-		echo "previousVideo=\"$currentVideo\"" >> "$progressBarConf"
+		Set_var startState "$_progressIteration" "$progressBarConf" str
+		Set_var maxState "$totalVideos" "$progressBarConf" str
+		Set_var currentVideo "$_newName.downsampled.mp4" "$progressBarConf" str
+		Set_var previousVideo "$currentVideo" "$progressBarConf" str
 
 		echo "Transcoding $currentVideo"
 		nice ffmpeg -y -i "$currentVideo" -c:v libx265 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
 		_newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
 		echo "Downsampled size: $_newVideoSize"
 		if $deleteOrNot; then
-		  echo "DELETING $currentVideo IN: "
-		  Countdown 10
-		  rm -v "$currentVideo"
-		  mv -v "$_newName.downsampled.mp4" "$_newName.mp4"
-	  fi
+			echo "DELETING $currentVideo IN: "
+			Countdown 10
+			rm -v "$currentVideo"
+			mv -v "$_newName.downsampled.mp4" "$_newName.mp4"
+		fi
 	done
 
 	sed -i "s|startState=.*|startState=$totalVideos|g" "$progressBarConf"
@@ -1109,7 +1108,7 @@ Change_Media_Directory()
 		fi
 	done
 
-	Change_variable defaultPath "$mediaPath" "$sourceFile" array
+	Set_var defaultPath "$mediaPath" "$sourceFile" array
 }
 
 Help()
@@ -1187,7 +1186,7 @@ if [ -n "$1" ]; then
 				 else
 					 Permissions $2
 					 shift 
-				 fi  ;;
+				 fi ;;
 			-r | --restart) systemctl restart jellyfin.service ;;
 			-s | --start) systemctl start jellyfin.service ;;
 			-S | --stop) systemctl stop jellyfin.service ;;

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -353,7 +353,6 @@ Import()
 		jellyman -S
 		rm -rf /opt/jellyfin
 		tar xf $importTar -C /
-		clear
 		source $sourceFile
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/
 		mv -f /opt/jellyfin/backup/jellyfin-backup.timer $jellyfinServiceLocation/

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1142,7 +1142,7 @@ Help()
 	echo "-d, --disable                Disable Jellyfin on System Start."
 	echo "-e, --enable                 Enable Jellyfin on System Start."
 	echo "-h, --help                   Print this Help."
-	echo "-i, --import                 [FILE.tar] Input file to Import jellyfin-backup.tar."
+	echo "-i, --import                 [FILE.tar - optional] Input file to Import jellyfin-backup.tar."
 	echo "-p, --permissions            [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory."
 	echo "-r, --restart                Restart Jellyfin."
 	echo "-s, --start                  Start Jellyfin."

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -391,7 +391,7 @@ Library_scan()
 	Has_sudo
 	source $sourceFile
 	Check_api_key
-	curl -d POST http://localhost:$networkPort/Library/Refresh?api_key=$apiKey
+	curl -d POST http://localhost:$httpPort/Library/Refresh?api_key=$apiKey
 }
 
 Import_api_key()

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -16,7 +16,9 @@ Backup()
 	tarPath=
 	_date=$(date +%m%d%Y%H%M)
 	fileName=jellyfin-backup-$_date.tar
-	mkdir /opt/jellyfin/backup
+	if [[ ! -d /opt/jellyfin/backup ]]; then
+		mkdir /opt/jellyfin/backup
+	fi
 	cp /usr/bin/jellyman /opt/jellyfin/backup/
 	cp /usr/bin/base_functions.sh /opt/jellyfin/backup/
 	cp /etc/jellyfin.conf /opt/jellyfin/backup/
@@ -28,7 +30,7 @@ Backup()
 		tarPath="$backupDirectory/$fileName"
 	fi
 
-	echo "$tarPath"
+	echo "> $tarPath"
 	echo "> Running backup, this may take some time..."
 	time tar cf "$tarPath" /opt/jellyfin
 	USER1=$(stat -c '%U' "$backupDirectory")
@@ -563,13 +565,17 @@ Update()
 			echo "> Supplied URL does not point to a $architecture.tar.gz.. EXITING..."
 			exit
 		fi
-	
-		mkdir /opt/jellyfin/update
+		
+		if [[ ! -d /opt/jellyfin/update ]]; then
+			mkdir /opt/jellyfin/update
+		fi
 		wget -P /opt/jellyfin/update/ $customVersionLink
 	
 	else
 		echo "> Getting current version from repository..."
-		mkdir /opt/jellyfin/update
+		if [[ ! -d /opt/jellyfin/update ]]; then
+			mkdir /opt/jellyfin/update
+		fi
 		stableReleases=$(curl -sL https://repo.jellyfin.org/?path=/server/linux/latest-stable/$architecture/)
 		jellyfin_archive=$(echo "$stableReleases" | grep -Po jellyfin_[^_]+-$architecture.tar.gz | head -1)
 		jellyfin=$(echo "$jellyfin_archive" | sed -r "s|-$architecture.tar.gz||g")

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -91,7 +91,7 @@ Backup_utility()
 	if [[ ! -d $backupDir ]]; then
 		Prompt_user dir "> Please enter your desired directory for backup archives"
 		backupDir="$promptDir"
-		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 20
+		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 20 "1-20"
 		maxBackupNumber=$promptNum
 		Set_var backupDir "backupDir" "$sourceFile" str
 		Set_var maxBackupNumber "maxBackupNumber" "$sourceFile" str
@@ -104,7 +104,7 @@ Backup_utility()
 	echo "> 4. Change max backups"
 	echo "> 5. Change frequency of backups"
 	echo
-	Prompt_user num "> Please select the number corresponding with the option you want to select." 1 5
+	Prompt_user num "> Please select the number corresponding with the option you want to select." 1 5 "1-5"
 	optionNumber=$promptNum
 	echo
 	
@@ -124,7 +124,7 @@ Backup_utility()
 
 	elif [[ $optionNumber == 4 ]]; then
 		# change max backups
-		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 50
+		Prompt_user num "> Please enter your desired maximum number of backup archives" 1 50 "1-50"
 		maxBackupNumber=$promptNum
 		Set_var "maxBackupNumber" "$maxBackupNumber" "$sourceFile"
 	
@@ -134,7 +134,7 @@ Backup_utility()
 		echo "> 2. Weekly backups"
 		echo "> 3. Monthly backups"
 		echo
-		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3
+		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
 		_optionNumber=$promptNum
 		echo
 	
@@ -238,7 +238,7 @@ Download_version()
 	echo $warning
 	echo "> $versionListNumbered"
 	echo "> Please enter the number corresponding with"
-	Prompt_user num "  the version you want to install" 1 $maxNumber
+	Prompt_user num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
 	versionToSwitchNumber=$promptNum
 	newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1)
 
@@ -271,7 +271,7 @@ Version_switch()
 	echo "> $installedVersionsClean" | cat -n
 	echo "> $warning"
 	echo "> Please enter the number corresponding with"
-	Prompt_user num "  the version you want to install" 1 $maxNumber
+	Prompt_user num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
 	versionToSwitchNumber=$promptNum
 	newVersion=$(echo "$installedVersions" | head -n $versionToSwitchNumber | tail -n 1)
 	jellyman -S
@@ -301,7 +301,7 @@ Remove_version()
 	echo
 	echo "> $warning"
 	echo "> Please enter the number corresponding with"
-	Prompt_user num "  the version you want to ERASE" 1 $maxNumber
+	Prompt_user num "  the version you want to ERASE" 1 $maxNumber "1-$maxNumber"
 	versionToSwitchNumber=$promptNum
 	versionToRemove=$(echo "$installedVersions" | head -n $versionToRemoveNumber | tail -n 1)
 	warning="ERROR: Please select one of the numbers provided!"
@@ -323,7 +323,7 @@ Import()
 	source $sourceFile
 	importTar=$1
 	
-	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive."
+	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive." 0 0 "/path/to/backup.tar"
 	importTar=$promptFile
 	echo
 	echo "+--------------------------------------------------------------------+"
@@ -364,7 +364,7 @@ Import()
 				chmod -Rfv 770 /opt/jellyfin
 				jellyman -s -t
 			else
-				Prompt_user usr "> Please enter a new LINUX user."
+				Prompt_user usr "> Please enter a new LINUX user." 0 0 "jellyfin"
 				defaultUser=$promptUsr
 				while id "$defaultUser" &>/dev/null; do
 					echo "> Cannot create $defaultUser as $defaultUser already exists..."
@@ -402,7 +402,7 @@ Import_api_key()
 	echo "> Create a API key by signing into Jellyfin, going to Dashboard, then"
 	echo "> clicking on API Keys under the Advanced section on the left."
 	echo
-	Prompt_user str "> Please paste your API Key"
+	Prompt_user str "> Please paste your API Key" 0 0 "API key"
 	newAPIKey=$promptStr
 	echo "> Logging new api key."
 	Set_var apiKey $newAPIKey "$sourceFile"
@@ -428,7 +428,7 @@ Http_port_change()
 	echo
 	echo "> Default http port is 8096"
 	if Is_jellyfin_setup; then
-		Prompt_user num "> Please enter the new http network port for Jellyfin" 1 100000
+		Prompt_user num "> Please enter the new http network port for Jellyfin" 1000 100000 "http port"
 		port=$promptNum
 		oldPort=$httpPort
 		Set_var httpPort $port "$sourceFile"
@@ -461,7 +461,7 @@ Https_port_change()
 	source $sourceFile
 	if Is_jellyfin_setup; then
 		echo "> Default https port is 8920"
-		Prompt_user num "> Please enter the new https network port for Jellyfin" 1 100000
+		Prompt_user num "> Please enter the new https network port for Jellyfin" 1000 100000 "https port"
 		port=$promptNum
 		oldPort=$httpsPort
 		Set_var httpsPort $port "$sourceFile"
@@ -640,7 +640,7 @@ Update_beta()
 	echo "$jellyfinNumbered"
 	echo
 
-	Prompt_user num "> Select which version to install" 1 $maxNumber
+	Prompt_user num "> Select which version to install" 1 $maxNumber "1-$maxNumber"
 	versionSelected=$promptNum
 	newVersionName=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1 | sed -r "s|-$architecture.tar.gz||g")
 	newVersionNumber=$(echo $newVersionName | sed -r 's/jellyfin_//g')
@@ -1007,11 +1007,11 @@ Transcode()
 	echo "|        TO RUN THIS COMMAND IN 'screen' THEN PRESSING         |"
 	echo "|                       CTRL + A THEN D                        |"
 	echo "|--------------------------------------------------------------|"
-	Prompt_user dir "> Please enter the path to the file(s)"
+	Prompt_user dir "> Please enter the directory to the file(s)"
 	_directoryToCorrect=$promptDir
 	echo
 	echo "> Please enter the desired GB per hour of video"
-	Prompt_user str "> EXAMPLE: 1 OR 2.5"
+	Prompt_user str "> EXAMPLE: 1 OR 2.5" 0 0 "float"
 	desiredGBperHour=$promptStr
 	
 	preset=0
@@ -1027,7 +1027,7 @@ Transcode()
 	echo "> 8: slower"
 	echo "> 9: veryslow"
 	echo
-	Prompt_user num "> Please choose a transcode preset" 1 9
+	Prompt_user num "> Please choose a transcode preset" 1 9 "1-9"
 	preset=$promptNum
 	echo
 	case "$preset" in
@@ -1046,7 +1046,7 @@ Transcode()
 	clear
 	echo '> Please enter a Constant Rate Factor (CRF) [20-30]'
 	echo "> 22-26 is recommended"
-	Prompt_user num "> 20 is better quality and 30 is lower quality" 20 30
+	Prompt_user num "> 20 is better quality and 30 is lower quality" 20 30 "20-30"
 	crf=$promptNum
 	echo
 	if Prompt_user yN "> Would you like to delete the original file(s) after transcode?"; then
@@ -1098,7 +1098,7 @@ Change_Media_Directory()
 		echo "|---------------------------------------------------------|"
 		echo
 		echo $warning
-		Prompt_user str " "
+		Prompt_user str " " 0 0 "/dir1 /dir2"
 		mediaPath=$promptStr
 		if areDirectories "$mediaPath"; then
 			continue=false

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -322,9 +322,26 @@ Import()
 	Has_sudo
 	source $sourceFile
 	importTar=$1
+	importDir=
 	
-	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive." 0 0 "/path/to/backup.tar"
-	importTar=$promptFile
+	if [[ ! -n $importTar ]]; then
+		if [[ -n $backupDir ]]; then
+			importDir=$backupDir	
+		else
+			Prompt_user dir "> Please enter the directory to the jellyfin-backup.tar archive(s)." 0 0 "/path/to/backup(s)"
+			importDir=$promptDir
+		fi
+		
+		listOfBackups=$(ls -1 $importDir | grep "jellyfin-backup".*".tar")
+		listOfBackupsNumbered=$(echo "$listOfBackups" | cat -n)
+		numberOfBackups=$(echo "$listOfBackups" | wc -l)
+		echo "$listOfBackupsNumbered"
+		Prompt_user num "> Please enter the number corresponding with the archive you wish to import." 1 $numberOfBackups "1-$numberOfBackups"
+		backupToImportNumber=$promptNum
+		backupToImport=$(echo "$listOfBackups" | head -n $backupToImportNumber | tail -n 1)
+		importTar="$importDir/$backupToImport"
+	fi
+	
 	echo
 	echo "+--------------------------------------------------------------------+"
 	echo "|                        ******CAUTION******                         |"

--- a/scripts/string
+++ b/scripts/string
@@ -1,0 +1,1 @@
+testVar=blap

--- a/setup.sh
+++ b/setup.sh
@@ -10,8 +10,16 @@ sourceFile=/opt/jellyfin/config/jellyman.conf
 
 Import()
 {
-	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive." 0 0 "/path/to/backup.tar"
-	importTar=$promptFile
+	Prompt_user dir "> Please enter the directory to the jellyfin-backup.tar archive(s)." 0 0 "/path/to/backup(s)"
+	importDir=$promptDir
+	listOfBackups=$(ls -1 $importDir | grep "jellyfin-backup".*".tar")
+	listOfBackupsNumbered=$(echo "$listOfBackups" | cat -n)
+	numberOfBackups=$(echo "$listOfBackups" | wc -l)
+	echo "$listOfBackupsNumbered"
+	Prompt_user num "> Please enter the number corresponding with the archive you wish to import." 1 $numberOfBackups "1-$numberOfBackups"
+	backupToImportNumber=$promptNum
+	backupToImport=$(echo "$listOfBackups" | head -n $backupToImportNumber | tail -n 1)
+	importTar="$importDir/$backupToImport"
 
 	echo "+--------------------------------------------------------------------+"
 	echo "|                        ******CAUTION******                         |"

--- a/setup.sh
+++ b/setup.sh
@@ -402,18 +402,11 @@ Update_jellyman()
 	cp -f $DIRECTORY/scripts/jellyman /usr/bin/jellyman
 	cp -f $DIRECTORY/scripts/jellyfin.sh /opt/jellyfin/jellyfin.sh
 	chmod +rx /usr/bin/jellyman
-	cp $DIRECTORY/conf/jellyfin.service /usr/lib/systemd/system/
 	cp $DIRECTORY/scripts/base_functions.sh /usr/bin/
 	chmod +rx /usr/bin/base_functions.sh
 	
 	# deletes all empty lines in $sourcefile
 	sed -i '/^ *$/d' $sourceFile
-	
-
-	if [[ ! -f $jellyfinServiceLocation/jellyfin-backup.timer ]]; then
-		cp $DIRECTORY/conf/jellyfin-backup.service /usr/lib/systemd/system/
-		cp $DIRECTORY/conf/jellyfin-backup.timer /usr/lib/systemd/system/
-	fi
 	
 	Set_var User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
 	
@@ -437,7 +430,14 @@ Update_jellyman()
 		jellyfinServiceLocation="/etc/systemd/system"
 		Set_var jellyfinServiceLocation "$jellyfinServiceLocation" "$sourceFile" str
 	fi
-
+	
+	cp $DIRECTORY/conf/jellyfin.service $jellyfinServiceLocation/
+	if [[ ! -f $jellyfinServiceLocation/jellyfin-backup.timer ]]; then
+		cp $DIRECTORY/conf/jellyfin-backup.service $jellyfinServiceLocation/
+		cp $DIRECTORY/conf/jellyfin-backup.timer $jellyfinServiceLocation/
+	fi
+	
+	systemctl daemon-reload
 	
 	if [[ ! -n $architecture ]]; then
 		architecture=

--- a/setup.sh
+++ b/setup.sh
@@ -445,7 +445,7 @@ Update_jellyman()
 	else
 		echo "> Okay, keeping $DIRECTORY"
 	fi
-	echo "...complete"
+	echo "> ...complete"
 	
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,11 +28,15 @@ Import()
 
 	if Prompt_user yN "> Import $importTar?"; then
 		echo "> IMPORTING $importTar"
-		rm -rf /opt/jellyfin
+		
+		if [[ -d /opt/jellyfin ]]; then
+			rm -rf /opt/jellyfin
+		fi
+		
 		tar xf $importTar -C /
 		source $sourceFile
 		mv -f $DIRECTORY/scripts/jellyman /usr/bin/
-		mv -f $DIRECTORY/scripts/jellyman/base_functions.sh /usr/bin/
+		mv -f $DIRECTORY/scripts/base_functions.sh /usr/bin/
 		chmod +rx /usr/bin/jellyman
 		chmod +rx /usr/bin/base_functions.sh
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ sourceFile=/opt/jellyfin/config/jellyman.conf
 
 Import()
 {
-	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive."
+	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive." 0 0 "/path/to/backup.tar"
 	importTar=$promptFile
 
 	echo "+--------------------------------------------------------------------+"
@@ -57,7 +57,7 @@ Import()
 				Install_dependancies
 				jellyman -s -t
 			else
-				Prompt_user usr "> Please enter a new LINUX user"
+				Prompt_user usr "> Please enter a new LINUX user" 0 0 "jellyfin"
 				defaultUser=$promptUsr
 		 
 				defaultUser=${defaultUser,,}
@@ -203,7 +203,7 @@ Previous_install()
 		isDataThere=false
 		isConfigThere=false
 		newDirectory=false
-		Prompt_user dir "> Where is Jellyfins intalled directory?"
+		Prompt_user dir "> Where is Jellyfins intalled directory?" 0 0 "/path/to/jellyfin/dir"
 		currentJellyfinDirectory=$promptDir
 		
 		#systemFileXML=$(find $currentJellyfinDirectory -name "system.xml")
@@ -268,7 +268,7 @@ Setup()
 	mkdir /opt/jellyfin /opt/jellyfin/old /opt/jellyfin/backup /opt/jellyfin/data /opt/jellyfin/cache /opt/jellyfin/config /opt/jellyfin/log /opt/jellyfin/cert
 	clear
 	Previous_install
-	Prompt_user usr "> Please enter the LINUX user for Jellyfin"
+	Prompt_user usr "> Please enter the LINUX user for Jellyfin" 0 0 "jellyfin"
 	defaultUser=$promptUsr
 	while id "$defaultUser" &>/dev/null; do
 		echo "> Cannot create $defaultUser as $defaultUser already exists..."
@@ -375,7 +375,7 @@ Setup()
 	fi
 	echo
 	echo "> Press 'q' to exit next screen"
-	read -p " Press ENTER to continue" ENTER
+	read -p "> Press ENTER to continue" ENTER
 	jellyman -t
 	echo
 	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
@@ -460,7 +460,7 @@ else
 		echo "2. Force update Jellyman"
 		echo "3. Import a jellyfin-backup.tar file"
 		echo
-		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3
+		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
 		optionNumber=$promptNum
 		echo
 	done

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ sourceFile=/opt/jellyfin/config/jellyman.conf
 
 Import()
 {
-	Prompt_user file "Please enter the path to the jellyfin-backup.tar archive."
+	Prompt_user file "> Please enter the path to the jellyfin-backup.tar archive."
 	importTar=$promptFile
 
 	echo "+--------------------------------------------------------------------+"
@@ -18,8 +18,8 @@ Import()
 	echo "|      This import procedurewill erase /opt/jellyfin COMPLETELY      |"
 	echo "+--------------------------------------------------------------------+"
 
-	if Prompt_user yN "Import $importTar?"; then
-		echo "IMPORTING $importTar"
+	if Prompt_user yN "> Import $importTar?"; then
+		echo "> IMPORTING $importTar"
 		jellyman -S
 		rm -rf /opt/jellyfin
 		tar xvf $importTar -C /
@@ -49,19 +49,19 @@ Import()
 			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
 			echo "+-----------------------------------------------------------------------------------------------+"
 			sleep 5
-			if Prompt_user yN "Would you like to create the LINUX user $defaultUser?"; then
-				echo "Great!"
+			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
+				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rfv 770 /opt/jellyfin
 				Install_dependancies
 				jellyman -s -t
 			else
-				Prompt_user usr "Please enter a new LINUX user"
+				Prompt_user usr "> Please enter a new LINUX user"
 				defaultUser=$promptUsr
 		 
 				defaultUser=${defaultUser,,}
-				echo "Linux user = $defaultUser"
+				echo "> Linux user = $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
 				
 				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
@@ -72,12 +72,12 @@ Import()
 		fi
 
 	else
-		echo "Returning..."
+		echo "> Returning..."
 		return 0
 		exit
 	fi
 
-	echo "Unblocking port $httpPort and $httpsPort..."
+	echo "> Unblocking port $httpPort and $httpsPort..."
 	if [ -x "$(command -v ufw)" ]; then
 		ufw allow $httpPort/tcp
 		ufw allow $httpsPort/tcp
@@ -96,12 +96,12 @@ Import()
 	fi
 
 	
-	if Prompt_user Yn "Would you like to remove the cloned git directory $DIRECTORY?"; then
-		echo "Removing cloned git directory:$DIRECTORY..."
+	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+		echo "> Removing cloned git directory:$DIRECTORY..."
 		rm -rf $DIRECTORY
 		cd ~/
 	else
-		echo "Okay, keeping $DIRECTORY"
+		echo "> Okay, keeping $DIRECTORY"
 	fi
 }
 
@@ -123,13 +123,13 @@ Install_dependancies()
 	packagesNeededRHEL='ffmpeg ffmpeg-devel ffmpeg-libs git openssl bc screen curl'
 	packagesNeededArch='ffmpeg git openssl bc screen curl'
 	packagesNeededOpenSuse='ffmpeg-4 git openssl bc screen curl'
-	echo "Preparing to install needed dependancies for Jellyfin..."
+	echo "> Preparing to install needed dependancies for Jellyfin..."
 
 	if [ -f /etc/os-release ]; then
 		source /etc/os-release
 		crbOrPowertools=
 		os_detected=true
-		echo "ID=$ID"
+		echo "> ID=$ID"
 		
 		if [[ $ID_LIKE == .*"rhel".* ]] || [[ $ID == "rhel" ]]; then
 			ID=rhel
@@ -181,10 +181,10 @@ Backup()
 	fileName=current-jellyfin-data.tar
 	if [[ $(echo "${backupDirectory: -1}") == "/" ]]; then
 		tarPath=$backupDirectory$fileName
-		echo "Saving your current metadata to --> $tarPath"
+		echo "> Saving your current metadata to --> $tarPath"
 	else
 		tarPath=$backupDirectory/$fileName
-		echo "Saving your current metadata to --> $tarPath"
+		echo "> Saving your current metadata to --> $tarPath"
 	fi
 	
 	cd $currentJellyfinDirectory
@@ -197,13 +197,13 @@ Backup()
 
 Previous_install()
 {
-	echo "WARNING: THIS OPTION IS HIGHLY UNSTABLE, ONLY USE IF YOU KNOW WHAT YOU'RE DOING!!!"
+	echo "> WARNING: THIS OPTION IS HIGHLY UNSTABLE, ONLY USE IF YOU KNOW WHAT YOU'RE DOING!!!"
 	echo
-	if Prompt_user yN "Is Jellyfin CURRENTLY installed on this system?"; then
+	if Prompt_user yN "> Is Jellyfin CURRENTLY installed on this system?"; then
 		isDataThere=false
 		isConfigThere=false
 		newDirectory=false
-		Prompt_user dir "Where is Jellyfins intalled directory?"
+		Prompt_user dir "> Where is Jellyfins intalled directory?"
 		currentJellyfinDirectory=$promptDir
 		
 		#systemFileXML=$(find $currentJellyfinDirectory -name "system.xml")
@@ -220,7 +220,7 @@ Previous_install()
 			isDataThere=false
 		else
 			isDataThere=true
-			echo "Found metadata!"
+			echo "> Found metadata!"
 		fi
 
 		if [ ! -d "$currentJellyfinDirectory/config" ]; then
@@ -228,13 +228,13 @@ Previous_install()
 			isConfigThere=false
 		else
 			isConfigThere=true
-			echo "Found config!"
+			echo "> Found config!"
 		fi
 
 		
 		if ! $isDataThere || ! $isConfigThere; then
 			echo "***ERROR*** - one or more directories not found..."
-			if Prompt_user Yn "Would you like to try a different directory?"; then
+			if Prompt_user Yn "> Would you like to try a different directory?"; then
 				currentJellyfinDirectory=null
 			else
 				exit
@@ -245,13 +245,13 @@ Previous_install()
 		cd /opt/jellyfin
 		tar xvf $tarPath -C ./
 	else
-		echo "Good call.."
+		echo "> Good call.."
 	fi
 }
 
 Setup()
 {
-	echo "Fetching newest stable Jellyfin version..."
+	echo "> Fetching newest stable Jellyfin version..."
 	Get_Architecture
 	jellyfin=
 	jellyfin_archive=
@@ -268,16 +268,16 @@ Setup()
 	mkdir /opt/jellyfin /opt/jellyfin/old /opt/jellyfin/backup /opt/jellyfin/data /opt/jellyfin/cache /opt/jellyfin/config /opt/jellyfin/log /opt/jellyfin/cert
 	clear
 	Previous_install
-	Prompt_user usr "Please enter the LINUX user for Jellyfin"
+	Prompt_user usr "> Please enter the LINUX user for Jellyfin"
 	defaultUser=$promptUsr
 	while id "$defaultUser" &>/dev/null; do
-		echo "Cannot create $defaultUser as $defaultUser already exists..."
-		Prompt_user usr "Please re-enter a new LINUX user for Jellyfin"
+		echo "> Cannot create $defaultUser as $defaultUser already exists..."
+		Prompt_user usr "> Please re-enter a new LINUX user for Jellyfin"
 		defaultUser=$promptUsr
 	done
 	
 	defaultUser=${defaultUser,,}
-	echo "Linux user = $defaultUser"
+	echo "> Linux user = $defaultUser"
 	useradd -rd /opt/jellyfin $defaultUser
 
 	if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
@@ -319,12 +319,12 @@ Setup()
 
 	Install_dependancies
 
-	echo "Setting Permissions for Jellyfin..."
+	echo "> Setting Permissions for Jellyfin..."
 	chown -R $defaultUser:$defaultUser /opt/jellyfin
 	chmod u+x $jellyfinDir/jellyfin.sh
 	chmod +rx /usr/bin/jellyman
 
-	echo "Unblocking port 8096 and 8920..."
+	echo "> Unblocking port 8096 and 8920..."
 	if [ -x "$(command -v ufw)" ]; then
 		ufw allow 8096/tcp
 		ufw allow 8920/tcp
@@ -346,7 +346,7 @@ Setup()
 		jellyman -e -s
 		echo
 		echo
-		echo "DONE"
+		echo "> DONE"
 		echo
 		echo "+-------------------------------------------------------------------+"
 		echo "|                 Navigate to http://localhost:8096/                |"
@@ -374,23 +374,23 @@ Setup()
 		echo "+-------------------------------------------------------------------+"
 	fi
 	echo
-	echo "Press 'q' to exit next screen"
+	echo "> Press 'q' to exit next screen"
 	read -p " Press ENTER to continue" ENTER
 	jellyman -t
 	echo
-	if Prompt_user Yn "Would you like to remove the cloned git directory $DIRECTORY?"; then
-		echo "Removing cloned git directory:$DIRECTORY..."
+	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+		echo "> Removing cloned git directory:$DIRECTORY..."
 		rm -rf $DIRECTORY
 		cd ~/
 	else
-		echo "Okay, keeping $DIRECTORY"
+		echo "> Okay, keeping $DIRECTORY"
 	fi
 }
 
 Update_jellyman()
 {
 	source $sourceFile
-	echo "Updating Jellyman - The Jellyfin Manager"
+	echo "> Updating Jellyman - The Jellyfin Manager"
 	cp -f $DIRECTORY/scripts/jellyman /usr/bin/jellyman
 	cp -f $DIRECTORY/scripts/jellyfin.sh /opt/jellyfin/jellyfin.sh
 	chmod +rx /usr/bin/jellyman
@@ -438,12 +438,12 @@ Update_jellyman()
 	fi
 
 
-	if Prompt_user Yn "Would you like to remove the cloned git directory $DIRECTORY?"; then
-		echo "Removing cloned git directory:$DIRECTORY..."
+	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+		echo "> Removing cloned git directory:$DIRECTORY..."
 		rm -rf $DIRECTORY
 		cd ~/
 	else
-		echo "Okay, keeping $DIRECTORY"
+		echo "> Okay, keeping $DIRECTORY"
 	fi
 	echo "...complete"
 	
@@ -460,7 +460,7 @@ else
 		echo "2. Force update Jellyman"
 		echo "3. Import a jellyfin-backup.tar file"
 		echo
-		Prompt_user num "Please select the number corresponding with the option you want to select." 1 3
+		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3
 		optionNumber=$promptNum
 		echo
 	done

--- a/setup.sh
+++ b/setup.sh
@@ -397,6 +397,7 @@ Setup()
 
 Update_jellyman()
 {
+	_skip=$1
 	source $sourceFile
 	echo "> Updating Jellyman - The Jellyfin Manager"
 	cp -f $DIRECTORY/scripts/jellyman /usr/bin/jellyman
@@ -445,13 +446,18 @@ Update_jellyman()
 		Set_var architecture "$architecture" "$sourceFile" str
 	fi
 
-
-	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+	if [[ $_skip == "y" ]]; then
 		echo "> Removing cloned git directory:$DIRECTORY..."
 		rm -rf $DIRECTORY
 		cd ~/
 	else
-		echo "> Okay, keeping $DIRECTORY"
+		if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+			echo "> Removing cloned git directory:$DIRECTORY..."
+			rm -rf $DIRECTORY
+			cd ~/
+		else
+			echo "> Okay, keeping $DIRECTORY"
+		fi
 	fi
 	echo "> ...complete"
 	
@@ -461,7 +467,7 @@ Has_sudo
 optionNumber=
 
 if [[ $1 == "-U" ]]; then
-	Update_jellyman
+	Update_jellyman y
 else
 	while [[ ! -n $optionNumber ]]; do
 		echo "1. Start first time setup"

--- a/setup.sh
+++ b/setup.sh
@@ -59,14 +59,13 @@ Import()
 			echo "|                   You may want to see who owns that configuration file with:                  |"
 			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
 			echo "+-----------------------------------------------------------------------------------------------+"
-			sleep 5
 			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
 				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
 				Install_dependancies
-				jellyman -s -t
+				jellyman -e -s -t
 			else
 				Prompt_user usr "> Please enter a new LINUX user" 0 0 "jellyfin"
 				defaultUser=$promptUsr

--- a/setup.sh
+++ b/setup.sh
@@ -42,8 +42,8 @@ Import()
 		systemctl daemon-reload
 		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
 		if id $defaultUser &>/dev/null; then 
-			chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-			chmod -Rfv 770 /opt/jellyfin
+			chown -Rf $defaultUser:$defaultUser /opt/jellyfin
+			chmod -Rf 770 /opt/jellyfin
 			Install_dependancies
 			jellyman -e -s
 			echo "> IMPORT COMPLETE!"
@@ -61,8 +61,8 @@ Import()
 			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
 				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
-				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-				chmod -Rfv 770 /opt/jellyfin
+				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rf 770 /opt/jellyfin
 				Install_dependancies
 				jellyman -s -t
 			else
@@ -73,8 +73,8 @@ Import()
 				echo "> Linux user = $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
 				
-				chown -Rfv $defaultUser:$defaultUser /opt/jellyfin
-				chmod -Rfv 770 /opt/jellyfin
+				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
+				chmod -Rf 770 /opt/jellyfin
 				Install_dependancies
 				jellyman -e -s -t
 			fi

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,6 @@ Import()
 
 	if Prompt_user yN "> Import $importTar?"; then
 		echo "> IMPORTING $importTar"
-		jellyman -S
 		rm -rf /opt/jellyfin
 		tar xf $importTar -C /
 		source $sourceFile

--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,6 @@ Import()
 		jellyman -S
 		rm -rf /opt/jellyfin
 		tar xf $importTar -C /
-		clear
 		source $sourceFile
 		mv -f /opt/jellyfin/backup/jellyman /usr/bin/
 		mv -f /opt/jellyfin/backup/base_functions.sh /usr/bin/

--- a/setup.sh
+++ b/setup.sh
@@ -30,7 +30,7 @@ Import()
 		echo "> IMPORTING $importTar"
 		jellyman -S
 		rm -rf /opt/jellyfin
-		tar xvf $importTar -C /
+		tar xf $importTar -C /
 		clear
 		source $sourceFile
 		mv -f /opt/jellyfin/backup/jellyman /usr/bin/
@@ -46,6 +46,7 @@ Import()
 			chmod -Rfv 770 /opt/jellyfin
 			Install_dependancies
 			jellyman -e -s
+			echo "> IMPORT COMPLETE!"
 		else
 			clear
 			echo "+-----------------------------------------------------------------------------------------------+"

--- a/setup.sh
+++ b/setup.sh
@@ -50,9 +50,11 @@ Import()
 			if Prompt_user Yn "Enable automatic backups?" 0 0 "Y/n"; then
 				systemctl enable --now jellyfin-backup.timer
 				Set_var autoBackups true "$sourceFile" str
+				Set_var "backupFrequency" "weekly" "$sourceFile"
 			else
 				systemctl enable --now jellyfin-backup.timer
 				Set_var autoBackups false "$sourceFile" str
+				Set_var "backupFrequency" "weekly" "$sourceFile"
 			fi
 		fi
 		
@@ -119,9 +121,8 @@ Import()
 	fi
 	
 	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
-		echo "> Removing cloned git directory:$DIRECTORY..."
+		echo "> Removing cloned git directory: $DIRECTORY..."
 		rm -rf $DIRECTORY
-		cd ~/
 	else
 		echo "> Okay, keeping $DIRECTORY"
 	fi
@@ -401,9 +402,8 @@ Setup()
 	jellyman -t
 	echo
 	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
-		echo "> Removing cloned git directory:$DIRECTORY..."
+		echo "> Removing cloned git directory: $DIRECTORY..."
 		rm -rf $DIRECTORY
-		cd ~/
 	else
 		echo "> Okay, keeping $DIRECTORY"
 	fi
@@ -461,14 +461,12 @@ Update_jellyman()
 	fi
 
 	if [[ $_skip == "y" ]]; then
-		echo "> Removing cloned git directory:$DIRECTORY..."
+		echo "> Removing cloned git directory: $DIRECTORY..."
 		rm -rf $DIRECTORY
-		cd ~/
 	else
 		if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
-			echo "> Removing cloned git directory:$DIRECTORY..."
+			echo "> Removing cloned git directory: $DIRECTORY..."
 			rm -rf $DIRECTORY
-			cd ~/
 		else
 			echo "> Okay, keeping $DIRECTORY"
 		fi

--- a/setup.sh
+++ b/setup.sh
@@ -31,8 +31,8 @@ Import()
 		rm -rf /opt/jellyfin
 		tar xf $importTar -C /
 		source $sourceFile
-		mv -f /opt/jellyfin/backup/jellyman /usr/bin/
-		mv -f /opt/jellyfin/backup/base_functions.sh /usr/bin/
+		mv -f $DIRECTORY/scripts/jellyman /usr/bin/
+		mv -f $DIRECTORY/scripts/jellyman/base_functions.sh /usr/bin/
 		chmod +rx /usr/bin/jellyman
 		chmod +rx /usr/bin/base_functions.sh
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/


### PR DESCRIPTION
## Additions
 - Added function `Del_var` which deletes a variable in a file.
 - Added more verbose prompt examles
 
## Fixed 
 - `jellyman -ls` command using old `$netowrkPort` variable, thus not actually calling Jellyfin to initiate library scan
 - Fixed mkdir errors
 - Fix for jellyfin.service not being placed in the right directory on some distributions.

## Changes
 - Changed `Change_Variable` function to `Set_var`
 - Changed `Change_xml_variable` function to `Set_xml_var`
 - Various functions now return 0 or 1
 - Changed setup.sh and jellyman to use `Set_var`, `Set_xml_var`, and `Del_var`
 - Got rid of spaces instead of tabs throughout code
 - All prompts now begin with `>`, and all inputs should begin with `>>>`
 - `jellyman -i` now gives a list of backups to import
 - Changed jellyfin-backup.tar date code for better readability
 - Removed verbosity of import tar command
 - Removed verbosity of chmod and chown commands
 - Fixed import from overwriting the main jellyman bash program. (Potentially resulting in a previous version of Jellyman...)
 - `jellyman -bu` got a face-lift