### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.7.7 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.7.8 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34-40, Ubuntu 22.04-24.04, Manjaro 21.3.6, EndeavourOS Artemis Neo/Nova/Cassini Nova, Linux Mint 21, and Rocky/Alma/RHEL Linux 8.6/9.0
 
@@ -133,69 +133,74 @@ sudo ./setup.sh
 ```
 
 # Example Install
-```
+
+```sh
 1. Start first time setup
 2. Force update Jellyman
 3. Import a jellyfin-backup.tar file
 
-Please select the number corresponding with the option you want to select.
->>> 1
-Fetching newest stable Jellyfin version...
-Is there a current install of Jellyfin on this system? [y/N] : N
+> Please select the number corresponding with the option you want to select.
+[1-3] >>> 1
 
-Please enter the default user for Jellyfin: jellyfin
+> Fetching newest stable Jellyfin version...
+> WARNING: THIS OPTION IS HIGHLY UNSTABLE, ONLY USE IF YOU KNOW WHAT YOU'RE DOING!!!
 
-Preparing to install needed dependancies for Jellyfin...
-ID=fedora
-Complete!
-Last metadata expiration check: 1:03:15 ago on Wed 24 Aug 2022 01:50:56 PM CDT.
-Package ffmpeg-5.0.1-3.fc36.x86_64 is already installed.
-Package ffmpeg-devel-5.0.1-3.fc36.x86_64 is already installed.
-Package ffmpeg-libs-5.0.1-3.fc36.x86_64 is already installed.
-Package git-2.37.2-1.fc36.x86_64 is already installed.
-Package openssl-1:3.0.5-1.fc36.x86_64 is already installed.
+> Is Jellyfin CURRENTLY installed on this system?
+[y/N] >>> no
+
+> Please enter the LINUX user for Jellyfin
+[jellyfin] >>> jellyfin
+> Linux user = jellyfin
+> Unpacking /home/smiley/jellyman/jellyfin_10.9.8-amd64.tar.gz...
+> Installing dependencies...
+> Preparing to install needed dependancies for Jellyfin...
+> ID=fedora
 Dependencies resolved.
 Nothing to do.
 Complete!
-Setting Permissions for Jellyfin...
-Unblocking port 8096 and 8920...
+Last metadata expiration check: 1:16:45 ago on Wed 31 Jul 2024 05:16:09 AM CDT.
+> Setting Permissions for Jellyfin...
+> Unblocking port 8096 and 8920...
+success
+success
+success
+
+> DONE
 
 +-------------------------------------------------------------------+
-|               Navigate to http://localhost:8096/                  |
-|        in your Web Browser to claim your Jellyfin server          |
+|                 Navigate to http://localhost:8096/                |
+|         in your Web Browser to claim your Jellyfin server         |
 +-------------------------------------------------------------------+
 
 +-------------------------------------------------------------------+
 |         To enable https please enter 'sudo jellyman -rc'          |
 |       (After you have navigated to the Jellyfin Dashboard)        |
 |                                                                   |
-|             To manage Jellyfin use 'jellyman -h'                  |
+|                To manage Jellyfin use 'jellyman -h'               |
 +-------------------------------------------------------------------+
 
-
-+-----------------------------------------------+
-|          No default directory found...        |
-|     Please enter the root directory for       |
-|              your Media Library               |
-|    DO NOT ENTER YOUR USER DIRECTORY AS IT     |
-|    WILL RESET PERMISSIONS OF THE ENTERED      |
-|       DIRECTORY TO YOUR JELLYFIN USER         |
-+-----------------------------------------------+
-/testMediaDirectory
-
+> Press 'q' to exit next screen
 ● jellyfin.service - Jellyfin Media Server - Installed by Jellyman
-     Loaded: loaded (/usr/lib/systemd/system/jellyfin.service; enabled; vendor preset: disabled)
-     Active: active (running) since Tue 2024-07-27 04:20:00 CDT; 1h ago
-   Main PID: 944 (jellyfin.sh)
-      Tasks: 18 (limit: 8736)
-     Memory: 254.3M
-        CPU: 22.173s
+     Loaded: loaded (/usr/lib/systemd/system/jellyfin.service; enabled; preset: disabled)
+    Drop-In: /usr/lib/systemd/system/service.d
+             └─10-timeout-abort.conf
+     Active: active (running) since Wed 2024-07-31 06:32:56 CDT; 5s ago
+   Main PID: 11878 (jellyfin.sh)
+      Tasks: 21 (limit: 23170)
+     Memory: 112.8M (peak: 128.1M)
+        CPU: 5.178s
      CGroup: /system.slice/jellyfin.service
-             ├─ 944 /bin/bash /opt/jellyfin/jellyfin.sh
-             └─ 947 /opt/jellyfin/jellyfin/jellyfin -d /opt/jellyfin/data -C /opt/jellyfin/cache -c /opt/jellyfin/config -l /opt/jellyfin/log --ffmpeg /usr/share/ffmpeg/ffmpeg
+             ├─11878 /bin/bash /opt/jellyfin/jellyfin.sh
+             └─11879 /opt/jellyfin/jellyfin/jellyfin -d /opt/jellyfin/data -C /opt/jellyfin/cache -c /opt/jellyfin/config -l /opt/jellyfin/log --ffmpeg /usr/bin/ffmpeg
 
-Would you like to remove the git cloned directory /home/smiley/jellyman? [Y/n] : Y
-Removing git cloned directory:/home/smiley/jellyman
+Jul 31 06:33:01 stronglap jellyfin.sh[11879]: [06:33:01] [INF] [6] MediaBrowser.MediaEncoding.Encoder.MediaEncoder: FFmpeg: /usr/bin/ffmpeg
+Jul 31 06:33:01 stronglap jellyfin.sh[11879]: [06:33:01] [INF] [6] Emby.Server.Implementations.ApplicationHost: ServerId: 264746fa848346df86e221b850267006
+Jul 31 06:33:01 stronglap jellyfin.sh[11879]: [06:33:01] [INF] [6] Emby.Server.Implementations.ApplicationHost: Core startup complete
+Jul 31 06:33:01 stronglap jellyfin.sh[11879]: [06:33:01] [INF] [6] Main: Startup complete 0:00:04.8788077
+
+> Would you like to remove the cloned git directory /home/smiley/jellyman?
+[Y/n] >>> no
+> Okay, keeping /home/smiley/jellyman
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ sudo ./setup.sh
 ```
 
 # Example Install
+[![Tutorial](https://img.youtube.com/vi/sXvEWvffcFc/0.jpg)](https://www.youtube.com/watch?v=sXvEWvffcFc)
 
 ```sh
 1. Start first time setup

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ sudo ./setup.sh
 ```
 
 # Example Install
+
+## Click to watch video example install
 [![Tutorial](https://img.youtube.com/vi/sXvEWvffcFc/0.jpg)](https://www.youtube.com/watch?v=sXvEWvffcFc)
 
 ```sh

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.7.7
+.B Jellyman - The Jellyfin Manager - v1.7.8
 
 .SH SYNOPSIS
 .B jellyman

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1048,7 +1048,7 @@ Transcode_file()
 		Set_var previousVideo "$currentVideo" "$progressBarConf" str
 
 		echo "> Transcoding $currentVideo"
-		nice ffmpeg -y -i "$currentVideo" -c:v libx265 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
+		nice ffmpeg -y -i "$currentVideo" -c:v libsvtav1 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
 		_newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
 		echo "> Downsampled size: $_newVideoSize"
 		if $deleteOrNot; then
@@ -1093,36 +1093,18 @@ Transcode()
 	preset=0
 	clear
 	echo
-	echo "> 1: ultrafast"
-	echo "> 2: superfast"
-	echo "> 3: veryfast"
-	echo "> 4: faster"
-	echo "> 5: fast"
-	echo '> 6: medium (RECOMMENDED)'
-	echo "> 7: slow"
-	echo "> 8: slower"
-	echo "> 9: veryslow"
+	echo "> Please choose a transcode preset"
+	echo "> 5-8 is recommended"
 	echo
-	Prompt_user num "> Please choose a transcode preset" 1 9 "1-9"
+	Prompt_user num "> Lower values are slower but have better compression." 1 12 "1-12"
 	preset=$promptNum
-	echo
-	case "$preset" in
-		1)	preset="ultrafast" ;;
-		2)	preset="superfast" ;;
-		3)	preset="veryfast" ;;
-		4)	preset="faster" ;;
-		5)	preset="fast" ;;
-		6)	preset="medium" ;;
-		7)	preset="slow" ;;
-		8)	preset="slower" ;;
-		9)	preset="veryslow" ;;
-	esac
 	
 	crf=0
 	clear
-	echo '> Please enter a Constant Rate Factor (CRF) [20-30]'
-	echo "> 22-26 is recommended"
-	Prompt_user num "> 20 is better quality and 30 is lower quality" 20 30 "20-30"
+	echo '> Please enter a Constant Rate Factor (CRF) [1-63]'
+	echo "> 25-35 is recommended"
+	echo
+	Prompt_user num "> Lower values correspond to higher quality but greater file size" 1 63 "1-63"
 	crf=$promptNum
 	echo
 	if Prompt_user yN "> Would you like to delete the original file(s) after transcode?"; then

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -877,7 +877,7 @@ Uninstall()
 	echo "|                        ******CAUTION******                        |"
 	echo "|                     Are you completely sure?                      |"
 	echo "|          This will delete all files relating to Jellyfin          |"
-	echo "|   and Jellyman, exceptthe Media Library and jellyfin-backup.tar   |"
+	echo "|   and Jellyman, except the Media Library and jellyfin-backup.tar  |"
 	echo "|-------------------------------------------------------------------|"
 	echo
 	if Prompt_user yN "> CONTINUE?"; then

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -84,7 +84,6 @@ Backup_utility()
 {
 	Has_sudo
 	while true; do
-		source $sourceFile
 		clear
 		optionNumber=
 		autoBackupSwitch=
@@ -96,10 +95,12 @@ Backup_utility()
 			maxBackupNumber=$promptNum
 			systemctl enable --now jellyfin-backup.timer
 			Set_var backupDir "$backupDir" "$sourceFile" str
-			Set_var maxBackupNumber 3 "$sourceFile" str
+			Set_var maxBackupNumber $maxBackupNumber "$sourceFile" str
 			Set_var autoBackups true "$sourceFile" str
 			Set_var backupFrequency "weekly" "$sourceFile"
 		fi
+		
+		source $sourceFile
 		
 		if $autoBackups; then
 			autoBackupSwitch="ON"

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.7.7"
+jellymanVersion="v1.7.8"
 sourceFile="/opt/jellyfin/config/jellyman.conf"
 source /usr/bin/base_functions.sh
 

--- a/setup.sh
+++ b/setup.sh
@@ -36,8 +36,8 @@ Import()
 		tar xf $importTar -C /
 		source $sourceFile
 		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
-		mv -f $DIRECTORY/scripts/jellyman /usr/bin/
-		mv -f $DIRECTORY/scripts/base_functions.sh /usr/bin/
+		cp -f $DIRECTORY/scripts/jellyman /usr/bin/
+		cp -f $DIRECTORY/scripts/base_functions.sh /usr/bin/
 		chmod +rx /usr/bin/jellyman
 		chmod +rx /usr/bin/base_functions.sh
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/

--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,7 @@ Import()
 		if id $defaultUser &>/dev/null; then 
 			chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 			chmod -Rf 770 /opt/jellyfin
-			Install_dependancies
+			Install_dependencies
 			jellyman -e -s
 			echo "> IMPORT COMPLETE!"
 		else
@@ -79,7 +79,7 @@ Import()
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
-				Install_dependancies
+				Install_dependencies
 				jellyman -e -s -t
 			else
 				Prompt_user usr "> Please enter a new LINUX user" 0 0 "jellyfin"
@@ -91,7 +91,7 @@ Import()
 				
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
-				Install_dependancies
+				Install_dependencies
 				jellyman -e -s -t
 			fi
 		fi
@@ -140,7 +140,7 @@ Get_Architecture()
 		esac
 }
 
-Install_dependancies()
+Install_dependencies()
 {
 	packagesNeededDebian='ffmpeg git net-tools openssl bc screen curl'
 	packagesNeededRHEL='ffmpeg ffmpeg-devel ffmpeg-libs git openssl bc screen curl'
@@ -266,9 +266,9 @@ Previous_install()
 		
 		Backup $HOME
 		cd /opt/jellyfin
-		tar xvf $tarPath -C ./
+		tar xf $tarPath -C ./
 	else
-		echo "> Good call.."
+		echo ""
 	fi
 }
 
@@ -330,7 +330,8 @@ Setup()
 	cp $DIRECTORY/conf/jellyfin.conf /etc/
 	jellyfinDir=/opt/jellyfin
 	jellyfinConfigFile=$jellyfinDir/config/jellyman.conf
-	tar xvzf $DIRECTORY/$jellyfin_archive
+	echo "> Unpacking $DIRECTORY/$jellyfin_archive..."
+	tar xzf $DIRECTORY/$jellyfin_archive
 	mv -f $DIRECTORY/jellyfin /opt/jellyfin/$jellyfin
 	ln -s $jellyfinDir/$jellyfin $jellyfinDir/jellyfin
 	Set_var architecture "$architecture" "$jellyfinConfigFile" str
@@ -340,7 +341,8 @@ Setup()
 	Set_var defaultUser "$defaultUser" "$jellyfinConfigFile" str
 	Set_var jellyfinServiceLocation "$jellyfinServiceLocation" "$jellyfinConfigFile" str
 
-	Install_dependancies
+	echo "> Installing dependencies..."
+	Install_dependencies
 
 	echo "> Setting Permissions for Jellyfin..."
 	chown -R $defaultUser:$defaultUser /opt/jellyfin
@@ -353,8 +355,8 @@ Setup()
 		ufw allow 8920/tcp
 		ufw reload
 	elif [ -x "$(command -v firewall-cmd)" ]; then
-		firewall-cmd --permanent --zone=public --add-port=8096/tcp
-		firewall-cmd --permanent --zone=public --add-port=8920/tcp
+		firewall-cmd --permanent --add-port=8096/tcp
+		firewall-cmd --permanent --add-port=8920/tcp
 		firewall-cmd --reload
 	else
 		echo "+-------------------------------------------------------------------+"
@@ -411,6 +413,12 @@ Setup()
 
 Update_jellyman()
 {
+	if [[ ! -f /usr/bin/jellyman ]]; then
+		echo "> ERROR: JELLYMAN IS NOT INSTALLED, CANNOT UPDATE."
+		echo "> Please run 'sudo ./setup.sh' and choose option #1" 
+		return 1
+		exit
+	fi
 	_skip=$1
 	source $sourceFile
 	echo "> Updating Jellyman - The Jellyfin Manager"

--- a/setup.sh
+++ b/setup.sh
@@ -40,8 +40,19 @@ Import()
 		cp -f $DIRECTORY/scripts/base_functions.sh /usr/bin/
 		chmod +rx /usr/bin/jellyman
 		chmod +rx /usr/bin/base_functions.sh
-		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/
-		mv -f /opt/jellyfin/backup/jellyfin-backup.timer $jellyfinServiceLocation/
+		
+		if [ -d /usr/lib/systemd/system ]; then
+			jellyfinServiceLocation="/usr/lib/systemd/system"
+			Set_var jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
+			mv -f /opt/jellyfin/backup/*.service /usr/lib/systemd/system/
+			mv -f /opt/jellyfin/backup/jellyfin-backup.timer /usr/lib/systemd/system/
+		else
+			jellyfinServiceLocation="/etc/systemd/system"
+			Set_var jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
+			mv -f /opt/jellyfin/backup/*.service /etc/systemd/system/
+			mv -f /opt/jellyfin/backup/jellyfin-backup.timer /etc/systemd/system/
+		fi
+		
 		systemctl daemon-reload
 		
 		if [[ -n $autoBackups ]] && $autoBackups; then

--- a/setup.sh
+++ b/setup.sh
@@ -374,7 +374,7 @@ Setup()
 		echo "> DONE"
 		echo
 		echo "+-------------------------------------------------------------------+"
-		echo "|                 Navigate to http://localhost:8096/                |"
+		echo "|      Navigate to http://localhost:8096/web/#/wizardstart.html     |"
 		echo "|         in your Web Browser to claim your Jellyfin server         |"
 		echo "+-------------------------------------------------------------------+"
 		echo


### PR DESCRIPTION
## Fixes
 - Prevents user from running `sudo ./setup.sh -U` without first having Jellyman installed.
 - Updated README.md to have a more current Example Install section
 - Fixed bug where systemD services would fail being moved during import using a different distribution

## Changes
 - Removed verbosity of extract tar command in setup.sh
 - `jellyman -tc` now uses AV1 format

## Additions
 - README.md now has a YouTube video link in the example install section.