### PR TITLE
Jellyman V1.8.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement on matrix chat
-@smiley-mcsmiles:matrix.org.
+reported via E-Mail: WOOSAAH@Proton.me
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ sudo ./setup.sh
 [1-3] >>> 1
 
 > Fetching newest stable Jellyfin version...
-> WARNING: THIS OPTION IS HIGHLY UNSTABLE, ONLY USE IF YOU KNOW WHAT YOU'RE DOING!!!
+> WARNING: THIS OPTION IS HIGHLY UNSTABLE, ONLY USE IF YOU KNOW WHAT YOU ARE DOING!!!
 
 > Is Jellyfin CURRENTLY installed on this system?
 [y/N] >>> no

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.7.9 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.8.0 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34-40, Ubuntu 22.04-24.04, Manjaro 21.3.6, EndeavourOS Artemis Neo/Nova/Cassini Nova, Linux Mint 21, and Rocky/Alma/RHEL Linux 8.6/9.0
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
 
 Jellyman is a lightweight BASH CLI (Command Line Interface) tool for installing and managing Jellyfin. Most notably, The ability to download and install the Jellyfin Media Server and switch between already downloaded versions of Jellyfin on the fly. As well as create a full backup (automatically or manually) so you can move or import all your metadata and user information to another machine.
 
+# Getting Started
+
+```sh
+git clone https://github.com/Smiley-McSmiles/jellyman
+cd jellyman
+chmod ug+x setup.sh
+sudo ./setup.sh
+cd ~/
+```
+
 # Features
 
 * **Setup** - Sets up the initial install.
@@ -99,7 +109,7 @@ Jellyman is a lightweight BASH CLI (Command Line Interface) tool for installing 
 ```
     └── Uses 'chmod -R 770' on your media directory.
 ```
-* **Get Version** - Get the current installed version of Jellyfin.
+* **Get Version** - Get the current installed version of Jellyfin and Jellyman.
 * **Remove Version** - Remove a specific version of Jellyfin
 ```
     └── Provides a list of currently installed versions of Jellyfin for you to remove.
@@ -112,24 +122,24 @@ Jellyman is a lightweight BASH CLI (Command Line Interface) tool for installing 
 ```
     └── Provides a list of currently installed versions of Jellyfin for you to switch to.
 ```
+* **View Logs** - Select from a list of logs to view.
 * **Recertify https** - Removes old https certifications and creates new **self signed** keys for the next 365 days. 
 * **Rename TV** - Batch renaming script for TV shows.
 * **Library Scan** - Tell Jellyfin to scan your media library.
-* **Change Port** - Change Jellyfins network port - Default = 8096.
+* **Change Port** - Change Jellyfins network ports.
 * **Change Media Directory** - Changes the Media Directory/Directories for Jellyman.
 * **Import API Key** - Import a new API key.
-* **Transcode** - Transcode a file/directory with a GB per hour filter (1.5GB is recommended)
+* **Transcode** - Transcode a file/directory with a GB per hour filter.
+```
+    ├── 1.5GB/hr is recommended for 1080p.
+    ├── 3GB/hr is recommended for 4k.
+    ├── Now uses AV1 codec (No HDR).
+    └── Please be careful as this can delete media files.
+         └──Select [no] to delete original files to preserve your media.
+```
 * **Uninstall** - Uninstalls Jellyfin and Jellyman completely 
 ```
     └── Does not remove backup archives or media files.
-```
-# Getting Started
-
-```sh
-git clone https://github.com/Smiley-McSmiles/jellyman
-cd jellyman
-chmod ug+x setup.sh
-sudo ./setup.sh
 ```
 
 # Example Install
@@ -237,12 +247,12 @@ COMMANDS:
 -rc, --recertify             Removes old https certifications and creates new ones for the next 365 days.
 -rn, --rename                Batch renaming script for TV shows.
 -ls, --library-scan          Tell Jellyfin to scan your media library.
--cp, --change-http           Change Jellyfins http network port - Default = 8096
+-cp, --change-http           Change Jellyfins http network port - Default = 8096.
 -cps, --change-https         Change Jellyfins https network port - Default = 8920.
 -ik, --import-key            Import an API key
 -md, --media-directory       Change the Media Directory for Jellyman.
--tc, --transcode             Transcode a file/directory with a GB per hour filter (1.5GB is recommended)
--tcp, --transcode-progress   View progress of the Transcode
+-tc, --transcode             Transcode a file/directory with a GB per hour filter (1.5GB is recommended).
+-tcp, --transcode-progress   View progress of the Transcode.
 -tcs, --transcode-stop       Stop the current transcode process.
 -X, --uninstall              Uninstall Jellyfin and Jellyman Completely.
 

--- a/jellyman.1
+++ b/jellyman.1
@@ -143,7 +143,7 @@ https://repo.jellyfin.org/files/server/linux/stable/
 
 .SH COPYRIGHT
 .PP
-Copyright 2021-2024 Smiley McSmiles. All rights reserved
+Copyright 2021-2024 WOOSAH (Smiley McSmiles). All rights reserved
 .PP
 https://www.github.com/Smiley-McSmiles/jellyman
 

--- a/jellyman.1
+++ b/jellyman.1
@@ -67,6 +67,8 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .B -rv, --remove-version        Remove a Jellyfin version.
 └── Provides a list of currently installed versions of Jellyfin for you to remove.
 .TP
+.B -vl, --view-log              Choose from a list of logs to view.
+.TP
 .B -rc, --recertify             Removes old https certifications and creates new ones for the next 365 days.
 .TP
 .B -rn, --rename                Batch renaming script for TV shows.

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.7.9
+.B Jellyman - The Jellyfin Manager - v1.8.0
 
 .SH SYNOPSIS
 .B jellyman

--- a/jellyman.1
+++ b/jellyman.1
@@ -23,6 +23,12 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .SS COMMANDS
 .TP
 .B -b, --backup                 [DIRECTORY] Input directory to output backup archive.
+.BR
+    ├── jellyman -b "/path/to/backup/directory" will output a jellyfin-backup.tar to that directory.
+.BR
+    ├── jellyman -ba will perform an automatic backup. But only if automatic backups are set up.
+.BR
+    └── jellyman -bu will launch the automatic backup setup utility.
 .TP
 .B -ba, --backup-auto           Perform an automatic backup.
 .TP
@@ -35,10 +41,14 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .B -h, --help                   Print this Help.
 .TP
 .B -i, --import                 [FILE.tar - optional] Input file to Import jellyfin-backup.tar.
-└── This will only work if on your new OS/setup you have your Media directories exactly the same as your old OS/setup.
+.BR
+    ├── Media metadata will only import if your new OS/setup and old OS/setup media folders are exactly the same.
+.BR
+    └── User and Web-UI configurations will still import just fine however.
 .TP
 .B -p, --permissions            [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory.
-└── Uses 'chmod -R 770' on your media directory.
+.BR
+    └── Uses 'chmod -R 770' on your media directory.
 .TP
 .B -r, --restart                Restart Jellyfin.
 .TP
@@ -49,23 +59,28 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .B -t, --status                 Status of Jellyfin.
 .TP
 .B -u, --update-jellyfin        [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
-└── NOTE - Supplied URL has to end with jellyfin_xx.x.x-<ARCHITECTURE>.tar.gz
+.BR
+    └── NOTE - Supplied URL has to end with jellyfin_xx.x.x-<ARCHITECTURE>.tar.gz
 .TP
 .B -U, --update-jellyman        Update Jellyman - The CLI Tool.
-└── Checks and downloads most recent version from GitHub.
+.BR
+    └── Checks and downloads most recent version from GitHub.
 .TP
 .B -ub, --update-beta           Update Jellyfin to the most recent Beta.
 .TP
 .B -v, --version                Get the current installed version of Jellyfin.
 .TP
 .B -vd, --version-download      Download an available Jellyfin version from the stable repository.
-└── Provides a list of currently installed versions of Jellyfin for you to download.
+.BR
+    └── Provides a list of currently installed versions of Jellyfin for you to download.
 .TP
 .B -vs, --version-switch        Switch Jellyfin version for another previously installed version.
-└── Provides a list of currently installed versions of Jellyfin for you to switch to.
+.BR
+    └── Provides a list of currently installed versions of Jellyfin for you to switch to.
 .TP
 .B -rv, --remove-version        Remove a Jellyfin version.
-└── Provides a list of currently installed versions of Jellyfin for you to remove.
+.BR
+    └── Provides a list of currently installed versions of Jellyfin for you to remove.
 .TP
 .B -vl, --view-log              Choose from a list of logs to view.
 .TP
@@ -83,14 +98,25 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .TP
 .B -md, --media-directory       Change the Media Directory for Jellyman.
 .TP
-.B -tc, --transcode             Transcode a file/directory with a GB per hour filter (1.5GB is recommended)
+.B -tc, --transcode             Transcode a file/directory with a GB per hour filter.
+.BR
+    ├── 1.5GB/hr is recommended for 1080p.
+.BR
+    ├── 3GB/hr is recommended for 4k.
+.BR
+    ├── Now uses AV1 codec (No HDR).
+.BR
+    └── Please be careful as this can delete media files.
+.BR
+        └── Select [no] to keep original files to preserve your media.
 .TP
-.B -tcp, --transcode-progress   View the progress of current transcode
+.B -tcp, --transcode-progress   View the progress of current transcode.
 .TP
 .B -tcs, --transcode-stop       Stop the current transcode process.
 .TP
 .B -X, --uninstall              Uninstall Jellyfin and Jellyman Completely.
-└── Ignores the Media Directory.
+.BR
+    └── Ignores the Media Directory.
 
 .SH EXAMPLE
 .TP
@@ -112,14 +138,16 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .SH URL TO NEW VERSIONS
 .PP
 List of supported official Jellyfin packages:
+.PP
 https://repo.jellyfin.org/files/server/linux/stable/
 
 .SH COPYRIGHT
 .PP
-Copyright 2021 Smiley McSmiles. All rights reserved
+Copyright 2021-2024 Smiley McSmiles. All rights reserved
+.PP
 https://www.github.com/Smiley-McSmiles/jellyman
 
 .SH CREDITS
 .PP
-Jellyman and this man page was created by Smiley McSmiles <SmileyMcSmiles@Proton.me>
+Jellyman and this man page was created by WOOSAH <WOOOSAHHH@Proton.me>
 

--- a/jellyman.1
+++ b/jellyman.1
@@ -149,5 +149,5 @@ https://www.github.com/Smiley-McSmiles/jellyman
 
 .SH CREDITS
 .PP
-Jellyman and this man page was created by WOOSAH <WOOOSAHHH@Proton.me>
+Jellyman and this man page was created by WOOSAH <WOOSAAH@Proton.me>
 

--- a/scripts/base_functions.sh
+++ b/scripts/base_functions.sh
@@ -289,3 +289,25 @@ AreDirectories()
 #fi
 }
 
+Log()
+{
+	# Log "ERROR | ERROR MESSAGE" $logFile
+	_errorMessage=$1
+	_logFile=$2
+	_logFileNoDir=$(echo "$_logFile" | rev | cut -d / -f 1 | rev)
+	_logFileDir=$(echo "$_logFile" | sed -r "s|$_logFileNoDir||g")
+	_date="[ $(date) ] |"
+
+	echo "$_date $_errorMessage" >> $_logFile
+	# echo "$_errorMessage"
+
+	USER1=$(stat -c '%U' "$_logFileDir")
+	chown -f $USER1:$USER1 $_logFile
+	chmod -f 770 $_logFile
+
+	_logFileLines=$(wc -l $_logFile | cut -d " " -f 1)
+
+	if [ $_logFileLines -ge 1000 ]; then
+		sed -i '1d' $_logFile
+	fi
+}

--- a/scripts/base_functions.sh
+++ b/scripts/base_functions.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-promptDir=null
-promptFile=null
-promptNum=null
-promptUsr=null
-promptStr=null
-Prompt_user()
+declare -g promptResult=null
+
+PromptUser()
 {
 	# prompt types = [Yn,yN,dir,file,num,usr,str]
 	_promptType=$1
@@ -64,7 +61,7 @@ Prompt_user()
 			while [[ ! -d $_dir ]]; do
 				read -p "[$_inputText] >>> " "_dir"
 				if [[ -d $_dir ]]; then
-					promptDir="$_dir"
+					promptResult="$_dir"
 					return 0
 				else
 					echo
@@ -79,7 +76,7 @@ Prompt_user()
 			while [[ ! -f $_file ]]; do
 				read -p "[$_inputText] >>> " "_file"
 				if [[ -f $_file ]]; then
-					promptFile="$_file"
+					promptResult="$_file"
 					return 0
 				else
 					echo
@@ -98,7 +95,7 @@ Prompt_user()
 					_num=null
 					echo "ERROR: Input must be between $_minNumber and $_maxNumber"
 				elif [[ $_num =~ ^[0-9]+$ ]]; then
-					promptNum=$_num
+					promptResult=$_num
 					return 0
 				else
 					echo
@@ -113,7 +110,7 @@ Prompt_user()
 			while [[ "$_usr" =~ [A-Z] ]] || [[ "$_usr" =~ \ |\' ]] || [[ "$_usr" == "" ]]; do
 				read -p "[$_inputText] >>> " "_usr"
 				if [[ ! "$_usr" =~ [A-Z] ]] && [[ ! "$_usr" =~ \ |\' ]] && [[ ! "$_usr" == "" ]]; then
-					promptUsr=$_usr
+					promptResult=$_usr
 					return 0
 				else
 					echo
@@ -128,7 +125,7 @@ Prompt_user()
 			while [[ ! -n $_str ]]; do
 				read -p "[$_inputText] >>> " "_str"
 				if [[ -n $_str ]]; then
-					promptStr=$_str
+					promptResult=$_str
 					return 0
 				else
 					echo
@@ -141,43 +138,43 @@ Prompt_user()
 		;;
 	esac
 # Default yes
-# if Prompt_user Yn "Example yes or no question?" 0 0 "Y/n"; then
+# if PromptUser Yn "Example yes or no question?" 0 0 "Y/n"; then
 #	echo "pass"
 # else
 #	echo "fail"
 # fi
 
 # Default no
-# if Prompt_user yN "Example yes or no question?" 0 0 "y/N"; then
+# if PromptUser yN "Example yes or no question?" 0 0 "y/N"; then
 #	echo "pass"
 # else
 #	echo "fail"
 # fi
 
 # Check for directory, return directory
-# Prompt_user dir "Enter a valid directory" 0 0 "/path/to/directory"
-# echo "Directory entered = $promptDir"
+# PromptUser dir "Enter a valid directory" 0 0 "/path/to/directory"
+# echo "Directory entered = $promptResult"
 
 # Check for file, return file
-# Prompt_user file "Enter a valid file" 0 0 "/path/to/file"
-# echo "File entered = $promptFile"
+# PromptUser file "Enter a valid file" 0 0 "/path/to/file"
+# echo "File entered = $promptResult"
 
 # Check if number, return number entered
-# Prompt_user num "Enter a valid number" minNumber maxNumber "$minNumber-$maxNumber"
-# echo "Number entered = $promptNum"
+# PromptUser num "Enter a valid number" minNumber maxNumber "$minNumber-$maxNumber"
+# echo "Number entered = $promptResult"
 
 # Check username for uppercase or spaces, return username
-# Prompt_user usr "Enter a valid username" 0 0 "username"
-# echo "Username entered = $promptUsr"
+# PromptUser usr "Enter a valid username" 0 0 "username"
+# echo "Username entered = $promptResult"
 
 # Check if string variable is not empty, return string
-# Prompt_user str "Enter a string" 0 0 "string"
-# echo "String entered = $promptStr"
+# PromptUser str "Enter a string" 0 0 "string"
+# echo "String entered = $promptResult"
 }
 
-Set_var()
+SetVar()
 {
-	# Set_var testVar "newVarContent" "fileToChange" varType
+	# SetVar testVar "newVarContent" "fileToChange" varType
 	varToChange=$1
 	newVarContent=$2
 	fileToChange=$3
@@ -199,9 +196,9 @@ Set_var()
 	fi
 }
 
-Del_var()
+DelVar()
 {
-	# Del_var varToDelete fileToChange
+	# DelVar varToDelete fileToChange
 	varToDelete=$1
 	fileToChange=$2
 	if ( ! grep -q $varToChange "$fileToChange" ); then
@@ -213,7 +210,7 @@ Del_var()
 	fi
 }
 
-Set_xml_var()
+SetXmlVar()
 {
 	# Change_xml_variable testVar "newVarContent" "fileToChange"
 	varToChange=$1
@@ -229,7 +226,7 @@ Set_xml_var()
 	fi
 }
 
-isVideo()
+IsVideo()
 {
 	_video=$1
 	if [[ $_video == *"."[mMaA][kKvVpP][iIvV4] ]]; then
@@ -251,7 +248,7 @@ Countdown()
 	printf "\n"
 }
 
-Has_sudo()
+HasSudo()
 {
 	if [ "$EUID" -ne 0 ]; then
 		echo "ERROR: Permission denied for $USER"
@@ -263,7 +260,7 @@ Has_sudo()
 	fi
 }
 
-areDirectories()
+AreDirectories()
 {
 	directoriesToCheck="$1"
 	isDirectory=true

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.7.9"
+jellymanVersion="v1.8.0"
 sourceFile="/opt/jellyfin/config/jellyman.conf"
 source /usr/bin/base_functions.sh
 
@@ -9,7 +9,7 @@ source /usr/bin/base_functions.sh
 
 Backup()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	# Backup /opt/jellyfin to passed directory
 	backupDirectory="$1"
@@ -50,9 +50,9 @@ Backup()
 	exit
 }
 
-Backup_auto()
+BackupAuto()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	if [[ ! -n $backupDir ]]; then
 		echo "> ERROR: AUTO-BACKUPS HAVE NOT BEEN SETUP. PLEASE RUN 'jellyman -bu'"
@@ -80,9 +80,9 @@ Backup_auto()
 	fi
 }
 
-Backup_utility()
+BackupUtility()
 {
-	Has_sudo
+	HasSudo
 	while true; do
 		clear
 		optionNumber=
@@ -90,15 +90,15 @@ Backup_utility()
 		source $sourceFile
 		
 		if [[ ! -d $backupDir ]]; then
-			Prompt_user dir "> Please enter your desired directory for backup archives"
-			backupDir="$promptDir"
-			Prompt_user num "> Please enter your desired maximum number of backup archives" 1 20 "1-20"
-			maxBackupNumber=$promptNum
+			PromptUser dir "> Please enter your desired directory for backup archives"
+			backupDir="$promptResult"
+			PromptUser num "> Please enter your desired maximum number of backup archives" 1 20 "1-20"
+			maxBackupNumber=$promptResult
 			systemctl enable --now jellyfin-backup.timer
-			Set_var backupDir "$backupDir" "$sourceFile" str
-			Set_var maxBackupNumber $maxBackupNumber "$sourceFile" str
-			Set_var autoBackups true "$sourceFile" str
-			Set_var backupFrequency "weekly" "$sourceFile"
+			SetVar backupDir "$backupDir" "$sourceFile" str
+			SetVar maxBackupNumber $maxBackupNumber "$sourceFile" str
+			SetVar autoBackups true "$sourceFile" str
+			SetVar backupFrequency "weekly" "$sourceFile"
 		fi
 		
 		source $sourceFile
@@ -118,37 +118,37 @@ Backup_utility()
 		echo "> 5. Change frequency of backups [ $backupFrequency ]"
 		echo "> 6. EXIT"
 		echo
-		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 6 "1-6"
-		optionNumber=$promptNum
+		PromptUser num "> Please select the number corresponding with the option you want to select." 1 6 "1-6"
+		optionNumber=$promptResult
 		echo
 		case $optionNumber in
 			"1")
 				# enable auto-backups
 				systemctl enable --now jellyfin-backup.timer
-				Set_var autoBackups true "$sourceFile" str
+				SetVar autoBackups true "$sourceFile" str
 				;;
 			"2")
 				# disable auto-backups
 				systemctl disable --now jellyfin-backup.timer
-				Set_var autoBackups false "$sourceFile" str
+				SetVar autoBackups false "$sourceFile" str
 				;;
 			"3")
 				# change backup folder
 				if [[ -n $backupDir ]]; then
 					echo "> Current directory for backups is $backupDir"
 				fi
-				Prompt_user dir "> Please enter your desired directory for backup archives"
-				backupDir="$promptDir"
-				Set_var "backupDir" "$backupDir" "$sourceFile"
+				PromptUser dir "> Please enter your desired directory for backup archives"
+				backupDir="$promptResult"
+				SetVar "backupDir" "$backupDir" "$sourceFile"
 				;;
 			"4")
 				# change max backups
 				if [[ -n $maxBackupNumber ]]; then
 					echo "> Current maximum backups allowed is $maxBackupNumber"
 				fi
-				Prompt_user num "> Please enter your desired maximum number of backup archives" 1 50 "1-50"
-				maxBackupNumber=$promptNum
-				Set_var maxBackupNumber "$maxBackupNumber" "$sourceFile"
+				PromptUser num "> Please enter your desired maximum number of backup archives" 1 50 "1-50"
+				maxBackupNumber=$promptResult
+				SetVar maxBackupNumber "$maxBackupNumber" "$sourceFile"
 				;;
 			"5")
 				# change frequency of backups
@@ -158,25 +158,25 @@ Backup_utility()
 				echo "> 2. Weekly backups"
 				echo "> 3. Monthly backups"
 				echo
-				Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
-				_optionNumber=$promptNum
+				PromptUser num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
+				_optionNumber=$promptResult
 				echo
 				jellyfinBackupTimer=/usr/lib/systemd/system/jellyfin-backup.timer
 				case $_optionNumber in
 					"1")
-						Set_var backupFrequency "daily" "$sourceFile"
+						SetVar backupFrequency "daily" "$sourceFile"
 						sed -i "s|OnCalendar.*|OnCalendar=*-*-* 01:00:00|g" $jellyfinBackupTimer
 						echo "> Backups will now be created every day at 1:00 AM"
 						read -p "> Press ENTER to exit" ENTER
 						;;
 					"2")
-						Set_var backupFrequency "weekly" "$sourceFile"
+						SetVar backupFrequency "weekly" "$sourceFile"
 						sed -i "s|OnCalendar.*|OnCalendar=Sun *-*-* 01:00:00|g" $jellyfinBackupTimer
 						echo "> Backups will now be created every Sunday at 1:00 AM"
 						read -p "> Press ENTER to exit" ENTER
 						;;
 					"3")
-						Set_var backupFrequency "monthly" "$sourceFile"
+						SetVar backupFrequency "monthly" "$sourceFile"
 						sed -i "s|OnCalendar.*|OnCalendar=*-*-01 01:00:00|g" $jellyfinBackupTimer
 						echo "> Backups will now be created on the 1st of every month at 1:00 AM"
 						read -p "> Press ENTER to exit" ENTER
@@ -192,7 +192,7 @@ Backup_utility()
 	done
 }
 
-isCurrentVersion()
+IsCurrentVersion()
 {
 	source $sourceFile
 	jellyfinVersionToDownload=$1
@@ -206,7 +206,7 @@ isCurrentVersion()
 	fi
 }
 
-isInstalledVersion()
+IsInstalledVersion()
 {
 	jellyfinVersionToDownload=$1
 	
@@ -219,7 +219,7 @@ isInstalledVersion()
 	fi
 }
 
-Check_disk_free()
+CheckDiskFree()
 {
 	source $sourceFile
 	if [ ! -n $defaultPath ]; then 
@@ -231,32 +231,32 @@ Check_disk_free()
 		echo "|    WILL RESET PERMISSIONS OF THE ENTERED      |"
 		echo "|       DIRECTORY TO YOUR JELLYFIN USER         |"
 		echo "+-----------------------------------------------+"
-		Prompt_user dir "> Enter a valid directory"
-		defaultPath="$promptDir"
+		PromptUser dir "> Enter a valid directory"
+		defaultPath="$promptResult"
 		defaultPath=($defaultPath)
-		Set_var defaultPath $defaultPath "$sourceFile" array
+		SetVar defaultPath $defaultPath "$sourceFile" array
 		df -h ${defaultPath[*]}
 	else 
 		df -h ${defaultPath[*]}
 	fi
 }
 
-Get_jellyman_version()
+GetJellymanVersion()
 {
 	echo "Jellyman $jellymanVersion"
 }
 
-Get_jellyfin_version()
+GetJellyfinVersion()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	versionFormatted=$(echo "$currentVersion" | sed -r "s|_| v|g" | sed -r "s|j|J|g")
 	echo "$versionFormatted"
 }
 
-Download_version()
+DownloadVersion()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	versionListVar=$(curl -sL https://repo.jellyfin.org/files/server/linux/stable/)
 	versionList=$(echo "$versionListVar" | grep '>v' | cut -d '>' -f 2 | cut -d '/' -f 1)
@@ -273,13 +273,13 @@ Download_version()
 	echo
 	echo "> Please select a stable version:"
 	echo $warning
-	echo "> $versionListNumbered"
+	echo "$versionListNumbered"
 	echo "> Please enter the number corresponding with"
-	Prompt_user num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
-	versionToSwitchNumber=$promptNum
+	PromptUser num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
+	versionToSwitchNumber=$promptResult
 	newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1)
 
-	if isCurrentVersion "jellyfin_$newVersionNumber" || isInstalledVersion "jellyfin_$newVersionNumber"; then
+	if IsCurrentVersion "jellyfin_$newVersionNumber" || IsInstalledVersion "jellyfin_$newVersionNumber"; then
 		versionToSwitchnumber=0
 		warning="ERROR: That Jellyfin version is already installed!"
 	else
@@ -290,9 +290,9 @@ Download_version()
 	fi
 }
 
-Version_switch()
+VersionSwitch()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	versionToSwitchNumber=0
 	installedVersions=$(ls /opt/jellyfin/ | grep "_")
@@ -308,20 +308,20 @@ Version_switch()
 	echo "$installedVersionsClean" | cat -n
 	echo "> $warning"
 	echo "> Please enter the number corresponding with"
-	Prompt_user num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
-	versionToSwitchNumber=$promptNum
+	PromptUser num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
+	versionToSwitchNumber=$promptResult
 	newVersion=$(echo "$installedVersions" | head -n $versionToSwitchNumber | tail -n 1)
 	jellyman -S
 	unlink /opt/jellyfin/jellyfin
 	ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
 	chown -Rf $defaultUser:$defaultUser /opt/jellyfin/jellyfin
-	Set_var currentVersion $newVersion "$sourceFile"
+	SetVar currentVersion $newVersion "$sourceFile"
 	jellyman -s
 }
 
-Remove_version()
+RemoveVersion()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	versionToRemoveNumber=0
 	versionToRemove=""
@@ -339,11 +339,11 @@ Remove_version()
 	echo
 	echo "> $warning"
 	echo "> Please enter the number corresponding with"
-	Prompt_user num "  the version you want to ERASE" 1 $maxNumber "1-$maxNumber"
-	versionToRemoveNumber=$promptNum
+	PromptUser num "  the version you want to ERASE" 1 $maxNumber "1-$maxNumber"
+	versionToRemoveNumber=$promptResult
 	versionToRemove=$(echo "$installedVersions" | head -n $versionToRemoveNumber | tail -n 1)
 	warning="ERROR: Please select one of the numbers provided!"
-	if isCurrentVersion $versionToRemove; then
+	if IsCurrentVersion $versionToRemove; then
 		warning="ERROR: $versionToRemove is the currently running version.
 Please use 'jellyman -vs' and choose a different version,
 before removing $versionToRemove"
@@ -357,7 +357,7 @@ before removing $versionToRemove"
 
 Import()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	importTar=$1
 	importDir=
@@ -366,16 +366,16 @@ Import()
 		if [[ -n $backupDir ]]; then
 			importDir=$backupDir	
 		else
-			Prompt_user dir "> Please enter the directory to the jellyfin-backup.tar archive(s)." 0 0 "/path/to/backup(s)"
-			importDir=$promptDir
+			PromptUser dir "> Please enter the directory to the jellyfin-backup.tar archive(s)." 0 0 "/path/to/backup(s)"
+			importDir=$promptResult
 		fi
 		
 		listOfBackups=$(ls -1 $importDir | grep "jellyfin-backup".*".tar")
 		listOfBackupsNumbered=$(echo "$listOfBackups" | cat -n)
 		numberOfBackups=$(echo "$listOfBackups" | wc -l)
 		echo "$listOfBackupsNumbered"
-		Prompt_user num "> Please enter the number corresponding with the archive you wish to import." 1 $numberOfBackups "1-$numberOfBackups"
-		backupToImportNumber=$promptNum
+		PromptUser num "> Please enter the number corresponding with the archive you wish to import." 1 $numberOfBackups "1-$numberOfBackups"
+		backupToImportNumber=$promptResult
 		backupToImport=$(echo "$listOfBackups" | head -n $backupToImportNumber | tail -n 1)
 		importTar="$importDir/$backupToImport"
 	fi
@@ -386,7 +386,7 @@ Import()
 	echo "|      This import procedurewill erase /opt/jellyfin COMPLETELY      |"
 	echo "+--------------------------------------------------------------------+"
 
-	if Prompt_user yN "> Import $importTar?"; then
+	if PromptUser yN "> Import $importTar?"; then
 		echo "> IMPORTING $importTar"
 		jellyman -S
 
@@ -403,14 +403,14 @@ Import()
 		if [[ -n $autoBackups ]] && $autoBackups; then
 			systemctl enable --now jellyfin-backup.timer
 		else
-			if Prompt_user Yn "Enable automatic backups?" 0 0 "Y/n"; then
+			if PromptUser Yn "Enable automatic backups?" 0 0 "Y/n"; then
 				systemctl enable --now jellyfin-backup.timer
-				Set_var autoBackups true "$sourceFile" str
-				Set_var "backupFrequency" "weekly" "$sourceFile"
+				SetVar autoBackups true "$sourceFile" str
+				SetVar "backupFrequency" "weekly" "$sourceFile"
 			else
 				systemctl enable --now jellyfin-backup.timer
-				Set_var autoBackups false "$sourceFile" str
-				Set_var "backupFrequency" "weekly" "$sourceFile"
+				SetVar autoBackups false "$sourceFile" str
+				SetVar "backupFrequency" "weekly" "$sourceFile"
 			fi
 		fi
 		
@@ -429,19 +429,19 @@ Import()
 			echo "|                   You may want to see who owns that configuration file with:                  |"
 			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
 			echo "+-----------------------------------------------------------------------------------------------+"
-			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
+			if PromptUser yN "> Would you like to create the LINUX user $defaultUser?"; then
 				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
 				jellyman -e -s -t
 			else
-				Prompt_user usr "> Please enter a new LINUX user." 0 0 "jellyfin"
-				defaultUser=$promptUsr
+				PromptUser usr "> Please enter a new LINUX user." 0 0 "jellyfin"
+				defaultUser=$promptResult
 				while id "$defaultUser" &>/dev/null; do
 					echo "> Cannot create $defaultUser as $defaultUser already exists..."
-					Prompt_user usr "> Please re-enter a new default Linux user for Jellyfin"
-					defaultUser=$promptUsr
+					PromptUser usr "> Please re-enter a new default Linux user for Jellyfin"
+					defaultUser=$promptResult
 				 done
 		 
 				defaultUser=${defaultUser,,}
@@ -460,29 +460,29 @@ Import()
 	fi
 }
 
-Library_scan()
+LibraryScan()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
-	Check_api_key
+	CheckApiKey
 	curl -d POST http://localhost:$httpPort/Library/Refresh?api_key=$apiKey
 }
 
-Import_api_key()
+ImportApiKey()
 {
-	Has_sudo
+	HasSudo
 	echo "> Create a API key by signing into Jellyfin, going to Dashboard, then"
 	echo "> clicking on API Keys under the Advanced section on the left."
 	echo
-	Prompt_user str "> Please paste your API Key" 0 0 "API key"
-	newAPIKey=$promptStr
+	PromptUser str "> Please paste your API Key" 0 0 "API key"
+	newAPIKey=$promptResult
 	echo "> Logging new api key."
-	Set_var apiKey $newAPIKey "$sourceFile"
+	SetVar apiKey $newAPIKey "$sourceFile"
 }
 
-Check_api_key()
+CheckApiKey()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	if [[ ! -n $apiKey ]]; then
 		echo "> ERROR: NO API KEY FOUND, RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
@@ -493,20 +493,20 @@ Check_api_key()
 	fi
 }
 
-Http_port_change()
+HttpPortChange()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	echo
 	echo "> Default http port is 8096"
-	if Is_jellyfin_setup; then
-		Prompt_user num "> Please enter the new http network port for Jellyfin" 1000 100000 "http port"
-		port=$promptNum
+	if IsJellyfinSetup; then
+		PromptUser num "> Please enter the new http network port for Jellyfin" 1000 100000 "http port"
+		port=$promptResult
 		oldPort=$httpPort
-		Set_var httpPort $port "$sourceFile"
+		SetVar httpPort $port "$sourceFile"
 		jellyman -S
-		Set_xml_var InternalHttpPort "$port" "/opt/jellyfin/config/network.xml"
-		Set_xml_var PublicHttpPort "$port" "/opt/jellyfin/config/network.xml"
+		SetXmlVar InternalHttpPort "$port" "/opt/jellyfin/config/network.xml"
+		SetXmlVar PublicHttpPort "$port" "/opt/jellyfin/config/network.xml"
 		jellyman -s
 		echo "> Unblocking port $port"
 		echo "> Blocking previous port $oldPort"
@@ -527,19 +527,19 @@ Http_port_change()
 	fi
 }
 
-Https_port_change()
+HttpsPortChange()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
-	if Is_jellyfin_setup; then
+	if IsJellyfinSetup; then
 		echo "> Default https port is 8920"
-		Prompt_user num "> Please enter the new https network port for Jellyfin" 1000 100000 "https port"
-		port=$promptNum
+		PromptUser num "> Please enter the new https network port for Jellyfin" 1000 100000 "https port"
+		port=$promptResult
 		oldPort=$httpsPort
-		Set_var httpsPort $port "$sourceFile"
+		SetVar httpsPort $port "$sourceFile"
 		jellyman -S
-		Set_xml_var InternalHttpsPort "$port" "/opt/jellyfin/config/network.xml"
-		Set_xml_var PublicHttpsPort "$port" "/opt/jellyfin/config/network.xml"
+		SetXmlVar InternalHttpsPort "$port" "/opt/jellyfin/config/network.xml"
+		SetXmlVar PublicHttpsPort "$port" "/opt/jellyfin/config/network.xml"
 		jellyman -s
 		echo "> Unblocking port $port"
 		echo "> Blocking previous port $oldPort"
@@ -563,7 +563,7 @@ Https_port_change()
 
 Permissions()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	checkForDefaultPath="yes"
 	directoryToFix=
@@ -583,7 +583,7 @@ Permissions()
 		exit
 	else
 		#Check if there is a recorded media library path for chown and chmod:
-		if areDirectories "${defaultPath[*]}" || [[ -d $defaultPath ]] || [[ -n $defaultPath ]]; then
+		if AreDirectories "${defaultPath[*]}" || [[ -d $defaultPath ]] || [[ -n $defaultPath ]]; then
 			echo "> Setting permissions for ${defaultPath[*]}"
 			time $(
 				chown -Rf $defaultUser:$defaultUser ${defaultPath[*]}
@@ -606,12 +606,12 @@ Status()
 	systemctl status jellyfin.service
 	echo
 	echo
-	Check_disk_free
+	CheckDiskFree
 }
 
 Update()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	customVersionLink=
 	customVersion=""
@@ -630,7 +630,7 @@ Update()
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|-$architecture.tar.gz||g")
 		fileType=$(echo $customVersion | cut -d '-' -f2)
 		
-		if isInstalledVersion $jellyfin; then
+		if IsInstalledVersion $jellyfin; then
 			exit
 		fi
 		
@@ -657,7 +657,7 @@ Update()
 		# echo "jellyfin_archive = $jellyfin_archive"
 		# echo "jellyfin = $jellyfin"
 		# echo "currentVersion = $currentVersion"
-		if ! isCurrentVersion $jellyfin && ! isInstalledVersion $jellyfin; then
+		if ! IsCurrentVersion $jellyfin && ! IsInstalledVersion $jellyfin; then
 			wget -O /opt/jellyfin/update/$newJellyfinArchive https://repo.jellyfin.org/files/server/linux/latest-stable/$architecture/$jellyfin_archive
 		else
 			exit
@@ -682,15 +682,15 @@ Update()
 
 	chown -R $defaultUser:$defaultUser /opt/jellyfin
 	echo "> Jellyfin updated to version $new_jellyfin_version"
-	Set_var currentVersion $jellyfin "$sourceFile"
+	SetVar currentVersion $jellyfin "$sourceFile"
 	jellyman -s -t
 }
 
 
 # needs testing when new beta is available
-Update_beta()
+UpdateBeta()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	betasAvailable=$(curl -sL https://repo.jellyfin.org/?path=/server/linux/latest-unstable/$architecture/)
 	jellyfinArchives=$(echo "$betasAvailable" | grep -o ">jellyfin_.*-$architecture.tar.gz<" | cut -d "'" -f 1 | sed -r "s|<||g" | sed -r "s|>||g" | head -1)
@@ -713,11 +713,11 @@ Update_beta()
 	echo "$jellyfinNumbered"
 	echo
 
-	Prompt_user num "> Select which version to install" 1 $maxNumber "1-$maxNumber"
-	versionSelected=$promptNum
+	PromptUser num "> Select which version to install" 1 $maxNumber "1-$maxNumber"
+	versionSelected=$promptResult
 	newVersionName=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1 | sed -r "s|-$architecture.tar.gz||g")
 	newVersionNumber=$(echo $newVersionName | sed -r 's/jellyfin_//g')
-	if isCurrentVersion $newVersionName || isInstalledVersion $newVersionName; then
+	if IsCurrentVersion $newVersionName || IsInstalledVersion $newVersionName; then
 		warning="> ERROR: That Jellyfin version is already installed!"
 		echo "> Press CTRL+C to exit..."
 	else
@@ -734,13 +734,13 @@ Update_beta()
 
 		chown -R $defaultUser:$defaultUser /opt/jellyfin
 		echo "> Jellyfin updated to version $newVersionNumber"
-		Set_var currentVersion $newVersionName "$sourceFile"
+		SetVar currentVersion $newVersionName "$sourceFile"
 		jellyman -s -t
 	fi
 }
 
 
-Is_jellyfin_setup()
+IsJellyfinSetup()
 {
 	if [ -f "/opt/jellyfin/config/network.xml" ]; then
 		return 0
@@ -756,9 +756,9 @@ Is_jellyfin_setup()
 	fi
 }
 
-Recertify_https()
+RecertifyHttps()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	echo "+------------------------------------------------------+"
 	echo "|  Creating OpenSSL self signed certificate for https. |"
@@ -767,14 +767,14 @@ Recertify_https()
 	echo "|           first time setup in Jellyfin               |"
 	echo "+------------------------------------------------------+"
 	source $sourceFile
-	if Is_jellyfin_setup; then
+	if IsJellyfinSetup; then
 		rm -fv /opt/jellyfin/cert/*
 		openssl req -x509 -newkey rsa:4096 -keyout /opt/jellyfin/cert/privkey.pem -out /opt/jellyfin/cert/cert.pem -days 365 -nodes -subj '/CN=jellyfin.lan'
 		openssl pkcs12 -export -out /opt/jellyfin/cert/jellyfin.pfx -inkey /opt/jellyfin/cert/privkey.pem -in /opt/jellyfin/cert/cert.pem -passout pass:
 		echo "> Enabling https..."
 		jellyman -S
-		Set_xml_var EnableHttps "true" "/opt/jellyfin/config/network.xml"
-		Set_xml_var CertificatePath "/opt/jellyfin/cert/jellyfin.pfx" "/opt/jellyfin/config/network.xml"
+		SetXmlVar EnableHttps "true" "/opt/jellyfin/config/network.xml"
+		SetXmlVar CertificatePath "/opt/jellyfin/cert/jellyfin.pfx" "/opt/jellyfin/config/network.xml"
 		chown -Rf $defaultUser:$defaultUser /opt/jellyfin/cert
 		chmod -Rf 770 /opt/jellyfin/cert
 		jellyman -s
@@ -783,9 +783,9 @@ Recertify_https()
 	fi
 }
 
-Rename_tv()
+RenameTv()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	nameOfTestFile=
 	loop=true
@@ -809,8 +809,8 @@ Rename_tv()
 		echo "|      NAMES ARE IN THE SAME LOCATION IN THE DIRECTORY         |"
 		echo "|--------------------------------------------------------------|"
 		echo
-		Prompt_user dir "> Please enter a directory"
-		directoryToCorrect=$promptDir
+		PromptUser dir "> Please enter a directory"
+		directoryToCorrect=$promptResult
 		clear
 		nameOfTestFile=$(ls -1 $directoryToCorrect | head -1)
 		if [ -f "$nameOfTestFile" ]; then
@@ -874,7 +874,7 @@ Rename_tv()
 
 Uninstall()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
 	echo "|-------------------------------------------------------------------|"
 	echo "|                        ******WARNING******                        |"
@@ -884,7 +884,7 @@ Uninstall()
 	echo "|   and Jellyman, except the Media Library and jellyfin-backup.tar  |"
 	echo "|-------------------------------------------------------------------|"
 	echo
-	if Prompt_user yN "> CONTINUE?"; then
+	if PromptUser yN "> CONTINUE?"; then
 		echo "> Goodbye..."
 		echo "> Removing Jellyfin and Jellyman in:"
 		Countdown 5
@@ -922,24 +922,23 @@ Uninstall()
 	fi
 }
 
-Kill_job()
+KillJob()
 {
 	# Run a job '_ID="jellyman-tc && COMMAND &'
-	# To kill a job `Kill_job "jellyman-tc"
+	# To kill a job `KillJob "jellyman-tc"
 	_jobName=$1
 	_jobID=$(jobs | grep "$_jobName" | cut -d "[" -f 2 | cut -d "]" -f 1)
 	kill %$_jobID
 }
 
-Dev_func()
+CallFunc()
 {
-	Has_sudo
+	HasSudo
 	source $sourceFile
-	_func=$1
 	$1
 }
 
-Progress_bar()
+ProgressBar()
 {
 	progressBarConf="/tmp/jellyman_transcode.conf"
 	if [ -f $progressBarConf ]; then
@@ -970,11 +969,11 @@ Progress_bar()
 	fi
 }
 
-View_Transcode_Progress()
+ViewTranscodeProgress()
 {
 	while true; do
 		clear
-		Progress_bar
+		ProgressBar
 		echo
 		echo "> CTRL+C to exit progress bar"
 		echo "> 'jellyman -tcp' to bring back Transcode Progress"
@@ -982,7 +981,7 @@ View_Transcode_Progress()
 	done
 }
 
-Qualify_Transcode()
+QualifyTranscode()
 {
 	videoToEdit="$1"
 	desiredGBperHour=$2
@@ -990,7 +989,7 @@ Qualify_Transcode()
 
 	videoSize=$(du -h "$videoToEdit" | cut -d "/" -f 1)
 	videoDuration=$(ffprobe -i "$videoToEdit" -show_entries format=duration -v quiet -of csv="p=0" | cut -d "." -f 1)
-	if isVideo "$videoToEdit"; then
+	if IsVideo "$videoToEdit"; then
 		_videoSizeGB=null
 		_videoTimeHours=$(bc -l <<< "$videoDuration/3600")
 		if [[ $videoSize == *"M"* ]]; then
@@ -1016,7 +1015,7 @@ Qualify_Transcode()
 	fi
 }
 
-Transcode_stop()
+TranscodeStop()
 {
 	qualifiedVideos="/tmp/jellyman_qualified_videos.txt"
 	progressBarConf="/tmp/jellyman_transcode.conf"
@@ -1025,7 +1024,7 @@ Transcode_stop()
 	rm $progressBarConf
 }
 
-Transcode_file()
+TranscodeFile()
 {
 	deleteOrNot=$1
 	preset=$2
@@ -1041,14 +1040,14 @@ Transcode_file()
 		currentVideo=$(cat "$qualifiedVideos" | head -n $iteration | tail -n 1)
 		_newName=$(echo $currentVideo | rev | cut -d "." -f 2 | rev)
 		_progressIteration=$(($iteration - 1))
-#		_progress=$(Progress_bar $_progressIteration $totalVideos)
+#		_progress=$(ProgressBar $_progressIteration $totalVideos)
 #		echo "$_progress" > $progressBarFile
 
 		echo '#!/bin/bash' > "$progressBarConf"
-		Set_var startState "$_progressIteration" "$progressBarConf" str
-		Set_var maxState "$totalVideos" "$progressBarConf" str
-		Set_var currentVideo "$_newName.downsampled.mp4" "$progressBarConf" str
-		Set_var previousVideo "$currentVideo" "$progressBarConf" str
+		SetVar startState "$_progressIteration" "$progressBarConf" str
+		SetVar maxState "$totalVideos" "$progressBarConf" str
+		SetVar currentVideo "$_newName.downsampled.mp4" "$progressBarConf" str
+		SetVar previousVideo "$currentVideo" "$progressBarConf" str
 
 		echo "> Transcoding $currentVideo"
 		nice ffmpeg -y -i "$currentVideo" -c:v libsvtav1 -c:a copy -movflags +faststart -preset $preset -crf $crf "$_newName.downsampled.mp4"
@@ -1086,12 +1085,12 @@ Transcode()
 	echo "|        TO RUN THIS COMMAND IN 'screen' THEN PRESSING         |"
 	echo "|                       CTRL + A THEN D                        |"
 	echo "|--------------------------------------------------------------|"
-	Prompt_user str "> Please enter the directory to the file(s)" 0 0 "directory"
-	_directoryToCorrect=$promptStr
+	PromptUser str "> Please enter the directory to the file(s)" 0 0 "directory"
+	_directoryToCorrect=$promptResult
 	echo
 	echo "> Please enter the desired GB per hour of video"
-	Prompt_user str "> EXAMPLE: 1 OR 2.5" 0 0 "float"
-	desiredGBperHour=$promptStr
+	PromptUser str "> EXAMPLE: 1 OR 2.5" 0 0 "float"
+	desiredGBperHour=$promptResult
 	
 	preset=0
 	clear
@@ -1099,18 +1098,18 @@ Transcode()
 	echo "> Please choose a transcode preset"
 	echo "> 5-8 is recommended"
 	echo
-	Prompt_user num "> Lower values are slower but have better compression." 1 12 "1-12"
-	preset=$promptNum
+	PromptUser num "> Lower values are slower but have better compression." 1 12 "1-12"
+	preset=$promptResult
 	
 	crf=0
 	clear
 	echo '> Please enter a Constant Rate Factor (CRF) [1-63]'
 	echo "> 25-35 is recommended"
 	echo
-	Prompt_user num "> Lower values correspond to higher quality but greater file size" 1 63 "1-63"
-	crf=$promptNum
+	PromptUser num "> Lower values correspond to higher quality but greater file size" 1 63 "1-63"
+	crf=$promptResult
 	echo
-	if Prompt_user yN "> Would you like to delete the original file(s) after transcode?"; then
+	if PromptUser yN "> Would you like to delete the original file(s) after transcode?"; then
 		deleteOrNot=true
 	else
 		deleteOrNot=false
@@ -1118,17 +1117,17 @@ Transcode()
 	
 	for item in $_directoryToCorrect
 	do
-		Qualify_Transcode "$item" $desiredGBperHour
+		QualifyTranscode "$item" $desiredGBperHour
 	done
 
-	screen -dmS jellyman_transcode jellyman --dev_func "Transcode_file $deleteOrNot $preset $crf"
+	screen -dmS jellyman_transcode jellyman --CallFunc "TranscodeFile $deleteOrNot $preset $crf"
 	sleep 1
-	View_Transcode_Progress
+	ViewTranscodeProgress
 }
 
 Update_jellyman()
 {
-	Has_sudo
+	HasSudo
 	jellymanManFile=$(curl -sL https://raw.githubusercontent.com/Smiley-McSmiles/jellyman/main/jellyman.1)
 	currentJellymanVersion=$(echo $jellymanManFile | grep " - v" | cut -d "v" -f2 | cut -d " " -f1)
 	if [[ "v$currentJellymanVersion" == $jellymanVersion ]]; then
@@ -1143,9 +1142,9 @@ Update_jellyman()
 	fi
 }
 
-Change_Media_Directory()
+ChangeMediaDirectory()
 {
-	Has_sudo
+	HasSudo
 	mediaPath=""
 	warning=""
 	continue=true
@@ -1159,19 +1158,19 @@ Change_Media_Directory()
 		echo "|---------------------------------------------------------|"
 		echo
 		echo $warning
-		Prompt_user str " " 0 0 "/dir1 /dir2"
-		mediaPath="$promptStr"
+		PromptUser str " " 0 0 "/dir1 /dir2"
+		mediaPath="$promptResult"
 		if [[ ! -d "$mediaPath" ]]; then
-			if areDirectories "$mediaPath"; then
+			if AreDirectories "$mediaPath"; then
 				continue=false
-				Set_var defaultPath "$mediaPath" "$sourceFile" array
+				SetVar defaultPath "$mediaPath" "$sourceFile" array
 				exit
 			else
 				warning="ERROR: Make sure each input is a directory!"
 				exit
 			fi
 		else
-			Set_var defaultPath "$mediaPath" "$sourceFile" dir
+			SetVar defaultPath "$mediaPath" "$sourceFile" dir
 			exit
 		fi
 	done
@@ -1240,8 +1239,8 @@ if [ -n "$1" ]; then
 		case "$1" in
 			-b | --backup) Backup "$2"
 				 shift ;;
-			-ba | --backup-auto) Backup_auto ;;
-			-bu | --backup-utility) Backup_utility ;;
+			-ba | --backup-auto) BackupAuto ;;
+			-bu | --backup-utility) BackupUtility ;;
 			-d | --disable) systemctl disable jellyfin.service ;;
 			-e | --enable) systemctl enable jellyfin.service ;;
 			-h | --help) Help ;;
@@ -1265,28 +1264,28 @@ if [ -n "$1" ]; then
 				 fi ;;
 			-U | --update-jellyman) Update_jellyman
 				 exit ;;
-			-ub | --update-beta) Update_beta ;;
-			-v | --version) Get_jellyfin_version
-					Get_jellyman_version ;;
-			-vd | --version-download) Download_version ;;
-			-vs | --version-switch) Version_switch ;;
-			-vr | --version-remove) Remove_version ;;
-			-rc | --recertify) Recertify_https ;;
-			-rn | --rename) Rename_tv ;;
-			-ls | --library-scan) Library_scan ;;
-			-cp | --change-http) Http_port_change ;;
-			-cps | --change-https) Https_port_change ;;
-			-ik | --import-key) Import_api_key ;;
-			-md | --media-directory) Change_Media_Directory ;;
+			-ub | --update-beta) UpdateBeta ;;
+			-v | --version) GetJellyfinVersion
+					GetJellymanVersion ;;
+			-vd | --version-download) DownloadVersion ;;
+			-vs | --version-switch) VersionSwitch ;;
+			-vr | --version-remove) RemoveVersion ;;
+			-rc | --recertify) RecertifyHttps ;;
+			-rn | --rename) RenameTv ;;
+			-ls | --library-scan) LibraryScan ;;
+			-cp | --change-http) HttpPortChange ;;
+			-cps | --change-https) HttpsPortChange ;;
+			-ik | --import-key) ImportApiKey ;;
+			-md | --media-directory) ChangeMediaDirectory ;;
 			-tc | --transcode) Transcode ;;
-			-tcp | --transcode-progress) View_Transcode_Progress ;;
-#			-tcf) Transcode_file $2 $3 $4
+			-tcp | --transcode-progress) ViewTranscodeProgress ;;
+#			-tcf) TranscodeFile $2 $3 $4
 #						shift
 #						shift
 #						shift ;;
-			-tcs | --transcode-stop) Transcode_stop ;;
+			-tcs | --transcode-stop) TranscodeStop ;;
 			-X | --uninstall) Uninstall ;;
-			--dev_func) Dev_func "$2"
+			--CallFunc) CallFunc "$2"
 									shift ;;
 			*) echo "> ERROR: Option $1 not recognized" 
 				Help ;;

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -5,7 +5,7 @@ sourceFile="/opt/jellyfin/config/jellyman.conf"
 source /usr/bin/base_functions.sh
 helpList="
 > Jellyman - The Jellyfin Manager $jellymanVersion
-- Created by Smiley McSmiles
+- Created by WOOSAH (Smiley McSmiles)
 
 > Syntax: jellyman -[COMMAND] [PARAMETER]
 > COMMANDS:

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -32,12 +32,12 @@ helpList="
 -vl   --view-log             Choose from a list of logs to view.
 -rc,  --recertify            Removes old https certifications and creates new ones for the next 365 days.
 -rn,  --rename               Batch renaming script for TV shows.
--cp,  --change-http          Change Jellyfins http network port - Default = 8096
+-cp,  --change-http          Change Jellyfins http network port - Default = 8096.
 -cps, --change-https         Change Jellyfins https network port - Default = 8920.
--ik,  --import-key           Import an API key
+-ik,  --import-key           Import an API key.
 -md,  --media-directory      Change the Media Directory for Jellyman.
--tc,  --transcode            Transcode a file/directory with a GB per hour filter (1.5GB is recommended)
--tcp, --transcode-progress   View progress of the Transcode
+-tc,  --transcode            Transcode a file/directory with a GB per hour filter (1.5GB is recommended).
+-tcp, --transcode-progress   View progress of the Transcode.
 -tcs, --transcode-stop       Stop the current transcode process.
 -X,   --uninstall            Uninstall Jellyfin and Jellyman Completely.
 

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,7 +1,54 @@
 #!/bin/bash
 jellymanVersion="v1.8.0"
+logFile=/opt/jellyfin/log/jellyman.log
 sourceFile="/opt/jellyfin/config/jellyman.conf"
 source /usr/bin/base_functions.sh
+helpList="
+> Jellyman - The Jellyfin Manager $jellymanVersion
+- Created by Smiley McSmiles
+
+> Syntax: jellyman -[COMMAND] [PARAMETER]
+> COMMANDS:
+-b,   --backup               [DIRECTORY] Input directory to output backup archive.
+-ba,  --backup-auto          Perform an automatic backup.
+-bu,  --backup-utility       Start the automatic backup utility.
+-d,   --disable              Disable Jellyfin on System Start.
+-e,   --enable               Enable Jellyfin on System Start.
+-h,   --help                 Print this Help.
+-i,   --import               [FILE.tar - optional] Input file to Import jellyfin-backup.tar.
+-p,   --permissions          [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory.
+-r,   --restart              Restart Jellyfin.
+-s,   --start                Start Jellyfin.
+-S,   --stop                 Stop Jellyfin.
+-t,   --status               Status of Jellyfin.
+-u,   --update-jellyfin      [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
+-U,   --update-jellyman      Update Jellyman - The Jellyfin Manager.
+-ub,  --update-beta          Update Jellyfin to the most recent Beta.
+-ls,  --library-scan         Tell Jellyfin to scan your media library.
+-v,   --version              Get the current installed version of Jellyfin.
+-vd,  --version-download     Download an available Jellyfin version from the stable repository.
+-vs,  --version-switch       Switch Jellyfin version for another previously installed version.
+-vr,  --version-remove       Remove a Jellyfin version.
+-vl   --view-log             Choose from a list of logs to view.
+-rc,  --recertify            Removes old https certifications and creates new ones for the next 365 days.
+-rn,  --rename               Batch renaming script for TV shows.
+-cp,  --change-http          Change Jellyfins http network port - Default = 8096
+-cps, --change-https         Change Jellyfins https network port - Default = 8920.
+-ik,  --import-key           Import an API key
+-md,  --media-directory      Change the Media Directory for Jellyman.
+-tc,  --transcode            Transcode a file/directory with a GB per hour filter (1.5GB is recommended)
+-tcp, --transcode-progress   View progress of the Transcode
+-tcs, --transcode-stop       Stop the current transcode process.
+-X,   --uninstall            Uninstall Jellyfin and Jellyman Completely.
+
+> To browse Jellyfin archives please use the link below.
+ - https://repo.jellyfin.org/files/server/linux/stable/
+
+> EXAMPLE:
+- To stop jellyfin, disable on startup, and then get status of the jellyfin service:
+	├── sudo jellyman --stop --disable --status
+	└── sudo jellyman -S -d -t
+"
 
 ###############################################################################
 # FUNCTIONS                                                                   #
@@ -27,6 +74,7 @@ Backup()
 	else
 		tarPath="$backupDirectory/$fileName"
 	fi
+	Log "BACKUP | Initiating backup to $tarPath" $logFile
 
 	echo "> $tarPath"
 	echo "> Running backup, this may take some time..."
@@ -55,11 +103,11 @@ BackupAuto()
 	HasSudo
 	source $sourceFile
 	if [[ ! -n $backupDir ]]; then
+		Log "ERROR | BACKUP-AUTO | AUTO-BACKUPS HAVE NOT BEEN SETUP." $logFile
 		echo "> ERROR: AUTO-BACKUPS HAVE NOT BEEN SETUP. PLEASE RUN 'jellyman -bu'"
 		exit
 	else
 		jellyman -b "$backupDir"
-		chown -Rf $defaultUser:$defaultUser "$backupDir/*.tar"
 
 		tarList=$(ls -1 "$backupDir"/*.tar)
 		newestTar=$(echo "$tarList" | tail -n 1)
@@ -67,6 +115,7 @@ BackupAuto()
 		tarCount=$(echo "$tarList" | wc -l)
 
 		while [[ $tarCount -gt $maxBackupNumber ]]; do
+			Log "BACKUP-AUTO | More than $maxBackupNumber, removing $oldestTar" $logFile
 			echo "> There are $tarCount backups."
 			echo "> Since there are more than $maxBackupNumber backups..."
 			echo "> Jellyman is removing $oldestTar"
@@ -97,8 +146,9 @@ BackupUtility()
 			systemctl enable --now jellyfin-backup.timer
 			SetVar backupDir "$backupDir" "$sourceFile" str
 			SetVar maxBackupNumber $maxBackupNumber "$sourceFile" str
-			SetVar autoBackups true "$sourceFile" str
+			SetVar autoBackups true "$sourceFile" sNewertr
 			SetVar backupFrequency "weekly" "$sourceFile"
+			Log "BACKUP-UTILITY | Setup BackupUtility at $backupDir max of $maxBackupNumber done weekly" $logFile
 		fi
 		
 		source $sourceFile
@@ -116,9 +166,10 @@ BackupUtility()
 		echo "> 3. Change backup folder"
 		echo "> 4. Change max backups [ $maxBackupNumber ]"
 		echo "> 5. Change frequency of backups [ $backupFrequency ]"
-		echo "> 6. EXIT"
+		echo "> 6. Create a jellyfin-backup.tar archive"
+		echo "> 7. EXIT"
 		echo
-		PromptUser num "> Please select the number corresponding with the option you want to select." 1 6 "1-6"
+		PromptUser num "> Please select the number corresponding with the option you want to select." 1 7 "1-7"
 		optionNumber=$promptResult
 		echo
 		case $optionNumber in
@@ -126,11 +177,13 @@ BackupUtility()
 				# enable auto-backups
 				systemctl enable --now jellyfin-backup.timer
 				SetVar autoBackups true "$sourceFile" str
+				Log "BACKUP-UTILITY | Automatic backups enabled" $logFile
 				;;
 			"2")
 				# disable auto-backups
 				systemctl disable --now jellyfin-backup.timer
 				SetVar autoBackups false "$sourceFile" str
+				Log "BACKUP-UTILITY | Automatic backups disabled" $logFile
 				;;
 			"3")
 				# change backup folder
@@ -140,6 +193,7 @@ BackupUtility()
 				PromptUser dir "> Please enter your desired directory for backup archives"
 				backupDir="$promptResult"
 				SetVar "backupDir" "$backupDir" "$sourceFile"
+				Log "BACKUP-UTILITY | Automatic backup location changed to $backupDir" $logFile
 				;;
 			"4")
 				# change max backups
@@ -149,6 +203,7 @@ BackupUtility()
 				PromptUser num "> Please enter your desired maximum number of backup archives" 1 50 "1-50"
 				maxBackupNumber=$promptResult
 				SetVar maxBackupNumber "$maxBackupNumber" "$sourceFile"
+				Log "BACKUP-UTILITY | Max automatic backups changed to $maxBackupNumber " $logFile
 				;;
 			"5")
 				# change frequency of backups
@@ -168,36 +223,63 @@ BackupUtility()
 						sed -i "s|OnCalendar.*|OnCalendar=*-*-* 01:00:00|g" $jellyfinBackupTimer
 						echo "> Backups will now be created every day at 1:00 AM"
 						read -p "> Press ENTER to exit" ENTER
+						Log "BACKUP-UTILITY | Frequency of automatic backups changed to daily" $logFile
 						;;
 					"2")
 						SetVar backupFrequency "weekly" "$sourceFile"
 						sed -i "s|OnCalendar.*|OnCalendar=Sun *-*-* 01:00:00|g" $jellyfinBackupTimer
 						echo "> Backups will now be created every Sunday at 1:00 AM"
 						read -p "> Press ENTER to exit" ENTER
+						Log "BACKUP-UTILITY | Frequency of automatic backups changed to weekly" $logFile
 						;;
 					"3")
 						SetVar backupFrequency "monthly" "$sourceFile"
 						sed -i "s|OnCalendar.*|OnCalendar=*-*-01 01:00:00|g" $jellyfinBackupTimer
 						echo "> Backups will now be created on the 1st of every month at 1:00 AM"
 						read -p "> Press ENTER to exit" ENTER
+						Log "BACKUP-UTILITY | Frequency of automatic backups changed to monthly" $logFile
 						;;
 				esac
 				systemctl daemon-reload
 				systemctl restart jellyfin-backup.timer
 				;;
 			"6")
+				jellyman -ba
+				exit
+				;;
+			"7")
 				exit
 				;;
 		esac
 	done
 }
 
-IsCurrentVersion()
+IsJellyfinSetup()
+{
+	if [ -f "/opt/jellyfin/config/network.xml" ]; then
+		Log "IS-JELLYFIN-SETUP | Checked if Jellyfin is setup, and it is" $logFile
+		return 0
+	else
+		Log "ERROR | IS-JELLYFIN-SETUP | /opt/jellyfin/config/network.xml NOT FOUND!" $logFile
+		echo "+--------------------------------------------------------------+"
+		echo "|                        ***WARNING***                         |"
+		echo "|             JELLYFIN DID NOT GET SET UP PROPERLY!            |"
+		echo "|        NO /opt/jellyfin/config/network.xml FILE FOUND        |"
+		echo "|  This is likely due to not completing the first time setup.  |"
+		echo "|     Navigate to http://localhost:8096/ to complete setup     |"
+		echo "+--------------------------------------------------------------+"
+		return 1
+	fi
+}
+
+isInstalledVersion()
 {
 	source $sourceFile
 	jellyfinVersionToDownload=$1
+
 	if [[ $jellyfinVersionToDownload == $currentVersion ]]; then
-		echo "> The installed version of Jellyfin matches the newest version available."
+		Log "ERROR | IS-INSTALLED-VERSION | $jellyfinVersionToDownload = $currentVersion" $logFile
+		echo "> ERROR: That version of Jellyfin is already installed."
 		echo "> Current Jellyfin version installed: $currentVersion"
 		return 0
 	else
@@ -206,12 +288,13 @@ IsCurrentVersion()
 	fi
 }
 
-IsInstalledVersion()
+isDownloadedVersion()
 {
 	jellyfinVersionToDownload=$1
 	
-	if [ -d /opt/jellyfin/$jellyfinVersionToDownload ]; then
-		echo "> The version to download matches an already installed version."
+	if [[ -d /opt/jellyfin/$jellyfinVersionToDownload ]]; then
+		Log "ERROR | IS-DOWNLOADED-VERSION | $jellyfinVersionToDownload IS DOWNLOADED ALREADY" $logFile
+		echo "> ERROR: That version of Jellyfin is already downloaded"
 		echo "> Please use 'jellyman -vs' to switch Jellyfin versions."
 		return 0
 	else
@@ -222,7 +305,8 @@ IsInstalledVersion()
 CheckDiskFree()
 {
 	source $sourceFile
-	if [ ! -n $defaultPath ]; then 
+	if [ ! -n $defaultPath ]; then
+		Log "ERROR | CHECK-DISK-FREE | NO DEFAULT MEDIA DIR FOUND!" $logFile
 		echo "+-----------------------------------------------+"
 		echo "|          No default directory found...        |"
 		echo "|     Please enter the root directory for       |"
@@ -254,7 +338,7 @@ GetJellyfinVersion()
 	echo "$versionFormatted"
 }
 
-DownloadVersion()
+VersionDownload()
 {
 	HasSudo
 	source $sourceFile
@@ -262,11 +346,7 @@ DownloadVersion()
 	versionList=$(echo "$versionListVar" | grep '>v' | cut -d '>' -f 2 | cut -d '/' -f 1)
 	versionListNumbered=$(echo "$versionList" | cat -n)
 	maxNumber=$(echo "$versionList" | wc -l)
-	newVersionNumber=""
-	versionToSwitchNumber=0
-	warning=""
 
-	clear
 	echo "> **WARNING** If Jellyfin v10.9.0 or later has been installed, it is impossible to revert to older versions as they will no longer be supported by Jellyman"
 	echo "> Current Jellyfin version installed"
 	echo "> $currentVersion"
@@ -277,17 +357,11 @@ DownloadVersion()
 	echo "> Please enter the number corresponding with"
 	PromptUser num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
 	versionToSwitchNumber=$promptResult
-	newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1)
-
-	if IsCurrentVersion "jellyfin_$newVersionNumber" || IsInstalledVersion "jellyfin_$newVersionNumber"; then
-		versionToSwitchnumber=0
-		warning="ERROR: That Jellyfin version is already installed!"
-	else
-		newVersionNumberNoLetters=$(echo "$newVersionNumber" | sed -r "s|v||g")
-		newVersionHyphen=$(echo "$newVersionNumberNoLetters"-)
-		echo "> https://repo.jellyfin.org/files/server/linux/stable/$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz"
-		jellyman -u "https://repo.jellyfin.org/files/server/linux/stable/$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz"
-	fi
+	newVersionNumber=$(echo "$versionList" | head -n $versionToSwitchNumber | tail -n 1 | sed -r "s|v||g")
+	newVersionHyphen=$(echo "$newVersionNumber"-)
+	echo "> https://repo.jellyfin.org/files/server/linux/stable/v$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz"
+	jellyman -u "https://repo.jellyfin.org/files/server/linux/stable/v$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz"
+	Log "VERSION-DOWNLOAD | Downloaded version from https://repo.jellyfin.org/files/server/linux/stable/v$newVersionNumber/$architecture/jellyfin_$newVersionHyphen$architecture.tar.gz" $logFile
 }
 
 VersionSwitch()
@@ -306,7 +380,6 @@ VersionSwitch()
 	echo
 	echo "> Jellyfin versions already downloaded:"
 	echo "$installedVersionsClean" | cat -n
-	echo "> $warning"
 	echo "> Please enter the number corresponding with"
 	PromptUser num "  the version you want to install" 1 $maxNumber "1-$maxNumber"
 	versionToSwitchNumber=$promptResult
@@ -316,43 +389,39 @@ VersionSwitch()
 	ln -s /opt/jellyfin/$newVersion /opt/jellyfin/jellyfin
 	chown -Rf $defaultUser:$defaultUser /opt/jellyfin/jellyfin
 	SetVar currentVersion $newVersion "$sourceFile"
+	echo "> Jellyfin is now using v$newVersion"
+	Log "VERSION-SWITCH | Jellyfin is now using v$newVersion" $logFile
 	jellyman -s
 }
 
-RemoveVersion()
+VersionRemove()
 {
 	HasSudo
 	source $sourceFile
-	versionToRemoveNumber=0
-	versionToRemove=""
 	installedVersions=$(ls /opt/jellyfin/ | grep "_")
 	installedVersionsClean=$(echo "$installedVersions" | sed -r "s|j|J|g" | sed -r "s|_| v|g")
 	maxNumber=$(echo "$installedVersions" | wc -l)
-	warning=
 
-	clear
 	echo "> Current Jellyfin version installed"
 	echo "> $currentVersion"
 	echo
 	echo "> Jellyfin versions already downloaded:"
 	echo "$installedVersionsClean" | cat -n
 	echo
-	echo "> $warning"
 	echo "> Please enter the number corresponding with"
 	PromptUser num "  the version you want to ERASE" 1 $maxNumber "1-$maxNumber"
 	versionToRemoveNumber=$promptResult
 	versionToRemove=$(echo "$installedVersions" | head -n $versionToRemoveNumber | tail -n 1)
-	warning="ERROR: Please select one of the numbers provided!"
-	if IsCurrentVersion $versionToRemove; then
-		warning="ERROR: $versionToRemove is the currently running version.
-Please use 'jellyman -vs' and choose a different version,
-before removing $versionToRemove"
-		versionToRemoveNumber=0
+
+	if isInstalledVersion $versionToRemove; then
+		echo "> ERROR: $versionToRemove is the currently running version. Before removing $versionToRemove" you must use jellyman -vs and choose a different version.
+		exit
 	fi
 
 	echo "> Removing /opt/jellyfin/$versionToRemove"
 	Countdown 5
 	rm -rfv /opt/jellyfin/$versionToRemove
+	Log "VERSION-REMOVE | Removed /opt/jellyfin/$versionToRemove" $logFile
 }
 
 Import()
@@ -361,6 +430,7 @@ Import()
 	source $sourceFile
 	importTar=$1
 	importDir=
+	logFile=/tmp/jellyman.log
 	
 	if [[ ! -n $importTar ]]; then
 		if [[ -n $backupDir ]]; then
@@ -383,18 +453,26 @@ Import()
 	echo
 	echo "+--------------------------------------------------------------------+"
 	echo "|                        ******CAUTION******                         |"
-	echo "|      This import procedurewill erase /opt/jellyfin COMPLETELY      |"
+	echo "|      This import procedure will erase /opt/jellyfin COMPLETELY     |"
 	echo "+--------------------------------------------------------------------+"
 
 	if PromptUser yN "> Import $importTar?"; then
+		echo "test1"
+		Log "IMPORT | Initiating import of $importTar" $logFile
+		echo "test2"
+		oldDefaultUser=$defaultUser
 		echo "> IMPORTING $importTar"
-		jellyman -S
+		jellyman -S -d
 
 		if [[ -d /opt/jellyfin ]]; then
 			rm -rf /opt/jellyfin
+			Log "IMPORT | Removed /opt/jellyfin" $logFile
 		fi
 
 		tar xf $importTar -C /
+		Log "IMPORT | $importTar restored at /opt/jellyfin" $logFile
+		cat "$logFile" >> /opt/jellyfin/log/jellyman.log
+		logFile=/opt/jellyfin/log/jellyman.log
 		source $sourceFile
 		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
 		mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/
@@ -402,54 +480,61 @@ Import()
 		systemctl daemon-reload
 		if [[ -n $autoBackups ]] && $autoBackups; then
 			systemctl enable --now jellyfin-backup.timer
+			Log "IMPORT | autoBackups=true, enabled jellyfin-backup.timer" $logFile
 		else
 			if PromptUser Yn "Enable automatic backups?" 0 0 "Y/n"; then
 				systemctl enable --now jellyfin-backup.timer
 				SetVar autoBackups true "$sourceFile" str
 				SetVar "backupFrequency" "weekly" "$sourceFile"
+				Log "IMPORT | User enabled automatic backups" $logFile
 			else
 				systemctl enable --now jellyfin-backup.timer
 				SetVar autoBackups false "$sourceFile" str
 				SetVar "backupFrequency" "weekly" "$sourceFile"
+				Log "IMPORT | User disabled automatic backups" $logFile
 			fi
 		fi
 		
-		if id "$defaultUser" &>/dev/null; then 
+		if [[ "$oldDefaultUser" == "$defaultUser" ]]; then
 			chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 			chmod -Rf 770 /opt/jellyfin
 			jellyman -e -s
 			echo "> IMPORT COMPLETE!"
+			Log "IMPORT | Imported LINUX user is the same as current LINUX user" $logFile
+			Log "IMPORT | Import completed" $logFile
 		else
-			clear
-			echo "+-----------------------------------------------------------------------------------------------+"
-			echo "|                                     *******ERROR*******                                       |"
-			echo "|          The imported default Jellyfin user($defaultUser) has not yet been created.           |"
-			echo "|    This error is likely due to a read error of the /opt/jellyfin/config/jellyman.conf file.   |"
-			echo "| The default user is usually created by Jellyman - The Jellyfin Manager, when running setup.sh.|"
-			echo "|                   You may want to see who owns that configuration file with:                  |"
-			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
-			echo "+-----------------------------------------------------------------------------------------------+"
-			if PromptUser yN "> Would you like to create the LINUX user $defaultUser?"; then
-				echo "> Great!"
+			groupdel $oldDefaultUser
+			userdel $oldDefaultUser
+			echo
+			echo "> The previous LINUX user $oldDefaultUser does not match the imported user $defaultUser"
+			if PromptUser yN "> Would you like to create the imported LINUX user $defaultUser?"; then
+				Log "IMPORT | Creating LINUX user $defaultUser" $logFile
+				echo "> Creating LINUX user $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
+				SetVar User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
+				Log "IMPORT | User $defaultUser $jellyfinServiceLocation/jellyfin.service" $logFile
 				jellyman -e -s -t
 			else
 				PromptUser usr "> Please enter a new LINUX user." 0 0 "jellyfin"
 				defaultUser=$promptResult
 				while id "$defaultUser" &>/dev/null; do
+					Log "IMPORT | Attempted to create $default user, but that user already exists" $logFile
 					echo "> Cannot create $defaultUser as $defaultUser already exists..."
 					PromptUser usr "> Please re-enter a new default Linux user for Jellyfin"
 					defaultUser=$promptResult
-				 done
+				done
 		 
 				defaultUser=${defaultUser,,}
 				echo "> Linux user = $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
+				Log "IMPORT | Created LINUX user $defaultUser" $logFile
 				
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
+				SetVar User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
+				Log "IMPORT | User $defaultUser $jellyfinServiceLocation/jellyfin.service" $logFile
 				jellyman -e -s -t
 			fi
 		fi
@@ -460,12 +545,28 @@ Import()
 	fi
 }
 
+ViewLog()
+{
+	HasSudo
+	logDir=/opt/jellyfin/log
+
+	listOfLogs=$(ls -1 $logDir)
+	listOfLogsNumbered=$(echo "$listOfLogs" | cat -n)
+	numberOfLogs=$(echo "$listOfLogs" | wc -l)
+	echo "$listOfLogsNumbered"
+	PromptUser num "> Please enter the number corresponding with the log you wish to view." 1 $numberOfLogs "1-$numberOfLogs"
+	logToViewNumber=$promptResult
+	logToView=$(echo "$listOfLogs" | head -n $logToViewNumber | tail -n 1)
+	less -FS $logDir/$logToView
+}
+
 LibraryScan()
 {
 	HasSudo
 	source $sourceFile
 	CheckApiKey
 	curl -d POST http://localhost:$httpPort/Library/Refresh?api_key=$apiKey
+	Log "LIBRARY-SCAN | Initiated library scan" $logFile
 }
 
 ImportApiKey()
@@ -478,6 +579,7 @@ ImportApiKey()
 	newAPIKey=$promptResult
 	echo "> Logging new api key."
 	SetVar apiKey $newAPIKey "$sourceFile"
+	Log "IMPORT-API-KEY | Imported new API key" $logFile
 }
 
 CheckApiKey()
@@ -485,6 +587,7 @@ CheckApiKey()
 	HasSudo
 	source $sourceFile
 	if [[ ! -n $apiKey ]]; then
+		Log "ERROR | CHECK-API-KEY | NO API KEY FOUND" $logFile
 		echo "> ERROR: NO API KEY FOUND, RUN 'sudo jellyman -ik' TO IMPORT A NEW KEY!"
 		return 1
 		exit
@@ -514,11 +617,14 @@ HttpPortChange()
 			ufw allow $port
 			ufw deny $oldPort
 			ufw reload
+			Log "HTTP-PORT-CHANGE | Used ufw to change port from $oldPort to $port" $logFile
 		elif [ -x "$(command -v firewall-cmd)" ]; then 
 			firewall-cmd --permanent --add-port=$port/tcp
 			firewall-cmd --permanent --remove-port=$oldPort/tcp
 			firewall-cmd --reload
+			Log "HTTP-PORT-CHANGE | Used firewallD to change port from $oldPort to $port" $logFile
 		else
+			Log "ERROR | HTTP-PORT-CHANGE | FAILED TO OPEN PORT $port! NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!" $logFile
 			echo "> ERROR: FAILED TO OPEN PORT $port!"
 			echo "> REASON: NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!"
 		fi
@@ -547,11 +653,14 @@ HttpsPortChange()
 			ufw allow $port
 			ufw deny $oldPort
 			ufw reload
+			Log "HTTPS-PORT-CHANGE | Used ufw to change port from $oldPort to $port" $logFile
 		elif [ -x "$(command -v firewall-cmd)" ]; then 
 			firewall-cmd --permanent --add-port=$port/tcp
 			firewall-cmd --permanent --remove-port=$oldPort/tcp
 			firewall-cmd --reload
+			Log "HTTPS-PORT-CHANGE | Used firewallD to change port from $oldPort to $port" $logFile
 		else
+			Log "ERROR | HTTPS-PORT-CHANGE | FAILED TO OPEN PORT $port! NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!" $logFile
 			echo "> ERROR: FAILED TO OPEN PORT $port!"
 			echo "> REASON: NO 'ufw' OR 'firewall-cmd' COMMAND FOUND!";
 		fi
@@ -575,9 +684,11 @@ Permissions()
 			chown -Rf $defaultUser:$defaultUser "$directoryToFix"
 			chmod -Rf 770 "$directoryToFix"
 			chmod -Rf ug+X "$directoryToFix"
+			Log "PERMISSIONS | Set permissions with chown $defaultUser:$defaultUser $directoryToFix" $logFile
 		)
 		echo "> ...DONE"
 	elif [[ ! -d "$1" ]] && [[ -n "$1" ]]; then
+		Log "ERROR | PERMISSIONS | User tried to set permissions, but supplied an invalid directory" $logFile
 		echo "> $1 is not a directory. Please enter a absolute path to your media"
 		echo "> EXITING..."
 		exit
@@ -589,8 +700,10 @@ Permissions()
 				chown -Rf $defaultUser:$defaultUser ${defaultPath[*]}
 				chmod -Rf 770 ${defaultPath[*]}
 				chmod -Rf ug+X ${defaultPath[*]}
+				Log "PERMISSIONS | Set permissions with chown $defaultUser:$defaultUser ${defaultPath[*]}" $logFile
 			)
 		else
+			Log "ERROR | PERMISSIONS | User tried to set permissions, but function could not find the defaultDir" $logFile
 			echo "> No default media directory found..."
 			echo "> Running sudo jellyman -md to change media directory in:"
 			Countdown 5
@@ -620,9 +733,12 @@ Update()
 	jellyfin=""
 	new_jellyfin_version=""
 	newJellyfinArchive=""
+
+	if [[ ! -d /opt/jellyfin/update ]]; then
+		mkdir /opt/jellyfin/update
+	fi
 	
 	if [[ $1 == *"://"* ]] ; then 
-		echo "> Fetching custom Jellyfin version..."
 		customVersionLink=$1
 		customVersion=$(echo $customVersionLink | rev | cut -d/ -f1 | rev)
 		jellyfin_archive=$customVersion
@@ -630,25 +746,19 @@ Update()
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|-$architecture.tar.gz||g")
 		fileType=$(echo $customVersion | cut -d '-' -f2)
 		
-		if IsInstalledVersion $jellyfin; then
-			exit
-		fi
-		
-		if [[ $fileType != "$architecture.tar.gz" ]]; then
+		if isDownloadedVersion $jellyfin; then
+			Log "ERROR | UPDATE | Tried to update with a custom URL, but the URL points to an already downloaded version" $logFile
+			return 1
+		elif [[ $fileType != "$architecture.tar.gz" ]]; then
+			Log "ERROR | UPDATE | Tried to update with a custom URL, but the URL doesn't point to a .tar.gz" $logFile
 			echo "> Supplied URL does not point to a $architecture.tar.gz.. EXITING..."
-			exit
+			return 1
 		fi
 		
-		if [[ ! -d /opt/jellyfin/update ]]; then
-			mkdir /opt/jellyfin/update
-		fi
+		echo "> Fetching custom Jellyfin version..."
 		wget -P /opt/jellyfin/update/ $customVersionLink
-	
+		Log "UPDATE | Updated Jellyfin with $customVersionLink" $logFile
 	else
-		echo "> Getting current version from repository..."
-		if [[ ! -d /opt/jellyfin/update ]]; then
-			mkdir /opt/jellyfin/update
-		fi
 		stableReleases=$(curl -sL https://repo.jellyfin.org/?path=/server/linux/latest-stable/$architecture/)
 		jellyfin_archive=$(echo "$stableReleases" | grep -Po jellyfin_[^_]+-$architecture.tar.gz | head -1)
 		jellyfin=$(echo "$jellyfin_archive" | sed -r "s|-$architecture.tar.gz||g")
@@ -657,8 +767,10 @@ Update()
 		# echo "jellyfin_archive = $jellyfin_archive"
 		# echo "jellyfin = $jellyfin"
 		# echo "currentVersion = $currentVersion"
-		if ! IsCurrentVersion $jellyfin && ! IsInstalledVersion $jellyfin; then
+		if ! isInstalledVersion $jellyfin && ! isDownloadedVersion $jellyfin; then
+			echo "> Getting current version from repository..."
 			wget -O /opt/jellyfin/update/$newJellyfinArchive https://repo.jellyfin.org/files/server/linux/latest-stable/$architecture/$jellyfin_archive
+			Log "UPDATE | Downloaded newest Jellyfin release found at https://repo.jellyfin.org/files/server/linux/latest-stable/$architecture/$jellyfin_archive" $logFile
 		else
 			exit
 		fi
@@ -671,18 +783,22 @@ Update()
 	tar xvzf /opt/jellyfin/update/$newJellyfinArchive -C /opt/jellyfin/
 	
 	if [ -n "$(ls -A /opt/jellyfin/jellyfin/ 2>/dev/null)" ]; then
-			mv -f /opt/jellyfin/jellyfin /opt/jellyfin/$jellyfin
+		mv -f /opt/jellyfin/jellyfin /opt/jellyfin/$jellyfin
+		Log "UPDATE | Successfully unpacked $newJellyfinArchive to /opt/jellyfin/$jellyfin" $logFile
 	else
-			echo "> Directory does not contain files..."
+		Log "ERROR | UPDATE | Attempted to unpack /opt/jellyfin/update/$newJellyfinArchive, but the archive is empty!" $logFile
+		echo "> ERROR Attempted to unpack /opt/jellyfin/update/$newJellyfinArchive, but the archive is empty!"
 	fi
 
 	ln -s /opt/jellyfin/$jellyfin /opt/jellyfin/jellyfin
 	echo "> Removing $jellyfin_archive"
+	Log "UPDATE | Removed $jellyfin_archive" $logFile
 	rm -rfv /opt/jellyfin/update
 
 	chown -R $defaultUser:$defaultUser /opt/jellyfin
 	echo "> Jellyfin updated to version $new_jellyfin_version"
 	SetVar currentVersion $jellyfin "$sourceFile"
+	Log "UPDATE | SetVar currentVersion=$jellyfin" $logFile
 	jellyman -s -t
 }
 
@@ -703,6 +819,7 @@ UpdateBeta()
 	warning=""
 	
 	if [[ ! $betasAvailable == .*"tar.gz".* ]]; then
+		Log "UPDATE-BETA | Tried to update to newest beta, but there are no betas available." $logFile
 		echo "> Sorry, no betas are available right now..."
 		exit
 	fi
@@ -717,7 +834,8 @@ UpdateBeta()
 	versionSelected=$promptResult
 	newVersionName=$(echo "$jellyfinArchives" | head -n $versionSelected | tail -n 1 | sed -r "s|-$architecture.tar.gz||g")
 	newVersionNumber=$(echo $newVersionName | sed -r 's/jellyfin_//g')
-	if IsCurrentVersion $newVersionName || IsInstalledVersion $newVersionName; then
+	if isInstalledVersion $newVersionName || isDownloadedVersion $newVersionName; then
+		Log "ERROR | UPDATE-BETA | Tried to update to a selected beta, but the beta is already installed" $logFile
 		warning="> ERROR: That Jellyfin version is already installed!"
 		echo "> Press CTRL+C to exit..."
 	else
@@ -726,33 +844,19 @@ UpdateBeta()
 		wget -O /opt/jellyfin/update/$newVersionName https://repo.jellyfin.org/files/server/linux/latest-unstable/$architecture/$newVersionArchive
 		echo "> Unpacking $newVersionArchive to /opt/jellyfin/..."
 		tar xvzf /opt/jellyfin/update/$newVersionArchive -C /opt/jellyfin/
+		Log "UPDATE-BETA | Unpacked $newVersionArchive to /opt/jellyfin/" $logFile
 		jellyman -S
 		unlink /opt/jellyfin/jellyfin
 		ln -s /opt/jellyfin/$newVersionName /opt/jellyfin/jellyfin
 		echo "> Removing $newVersionArchive"
 		rm -rfv /opt/jellyfin/update
+		Log "UPDATE-BETA | Removed /$newVersionArchive" $logFile
 
 		chown -R $defaultUser:$defaultUser /opt/jellyfin
 		echo "> Jellyfin updated to version $newVersionNumber"
 		SetVar currentVersion $newVersionName "$sourceFile"
+		Log "UPDATE-BETA | SetVar currentVersion=$newVersionName" $logFile
 		jellyman -s -t
-	fi
-}
-
-
-IsJellyfinSetup()
-{
-	if [ -f "/opt/jellyfin/config/network.xml" ]; then
-		return 0
-	else
-		echo "+--------------------------------------------------------------+"
-		echo "|                        ***WARNING***                         |"
-		echo "|             JELLYFIN DID NOT GET SET UP PROPERLY!            |"
-		echo "|        NO /opt/jellyfin/config/network.xml FILE FOUND        |"
-		echo "|  This is likely due to not completing the first time setup.  |"
-		echo "|     Navigate to http://localhost:8096/ to complete setup     |"
-		echo "+--------------------------------------------------------------+"
-		return 1
 	fi
 }
 
@@ -778,6 +882,7 @@ RecertifyHttps()
 		chown -Rf $defaultUser:$defaultUser /opt/jellyfin/cert
 		chmod -Rf 770 /opt/jellyfin/cert
 		jellyman -s
+		Log "RECERTIFY-HTTPS | Finished recertify process" $logFile
 	else
 		exit
 	fi
@@ -868,6 +973,7 @@ RenameTv()
 				chown -f $defaultUser:$defaultUser "$newItemName"
 				chmod -f 770 "$newItemName"
 				echo
+				Log "RENAME-TV | $item -> $newItemName" $logFile
 			fi
 	done
 }
@@ -929,6 +1035,7 @@ KillJob()
 	_jobName=$1
 	_jobID=$(jobs | grep "$_jobName" | cut -d "[" -f 2 | cut -d "]" -f 1)
 	kill %$_jobID
+	Log "KILL-JOB | Killed job $_jobID" $logFile
 }
 
 CallFunc()
@@ -1006,6 +1113,7 @@ QualifyTranscode()
 			echo "> Video size GB: $_videoSizeGB"
 			echo "> Current GB/Hour: $_videoRatio"
 			echo "$videoToEdit" >> $qualifiedVideos
+			Log "QUALIFY-TRANSCODE | Added file $videoToEdit to transcode list, Duration:$_videoTimeHours Hrs Size:$_videoSizeGB GiB GiB/Hr:$_videoRatio" $logFile
 		else
 			echo "> $videoToEdit is less than $desiredGBperHour GB/Hour, skipping..."
 		fi
@@ -1020,6 +1128,7 @@ TranscodeStop()
 	qualifiedVideos="/tmp/jellyman_qualified_videos.txt"
 	progressBarConf="/tmp/jellyman_transcode.conf"
 	screen -XS jellyman_transcode quit
+	Log "TRANSCODE-STOP | Stopped transcodes" $logFile
 	rm $qualifiedVideos
 	rm $progressBarConf
 }
@@ -1054,10 +1163,11 @@ TranscodeFile()
 		_newVideoSize=$(du -h "$_newName.downsampled.mp4" | cut -d "/" -f 1)
 		echo "> Downsampled size: $_newVideoSize"
 		if $deleteOrNot; then
-			echo "> DELETING $currentVideo IN: "
+			echo "> DELETING $currentVideo IN:"
 			Countdown 10
 			rm -v "$currentVideo"
 			mv -v "$_newName.downsampled.mp4" "$_newName.mp4"
+			Log "TRANSCODE-FILE | Replaced $currentVideo with $_newName.downsampled.mp4" $logFile
 		fi
 	done
 
@@ -1121,6 +1231,7 @@ Transcode()
 	done
 
 	screen -dmS jellyman_transcode jellyman --CallFunc "TranscodeFile $deleteOrNot $preset $crf"
+	Log "TRANSCODE | directoryToCorrect=$_directoryToCorrect, preset=$preset, crf=$crf, deleteOrNot=$deleteOrNot" $logFile
 	sleep 1
 	ViewTranscodeProgress
 }
@@ -1132,6 +1243,7 @@ Update_jellyman()
 	currentJellymanVersion=$(echo $jellymanManFile | grep " - v" | cut -d "v" -f2 | cut -d " " -f1)
 	if [[ "v$currentJellymanVersion" == $jellymanVersion ]]; then
 		echo "> Jellyman is up to date. No new versions available."
+		Log "ERROR | UPDATE-JELLYMAN | Tried to update Jellyman, but Jellyman is already at the current version" $logFile
 		exit
 	else
 		echo "> Updating Jellyman - The Jellyfin Manager from $jellymanVersion to v$currentJellymanVersion"
@@ -1139,6 +1251,7 @@ Update_jellyman()
 		cd jellyman
 		chmod ug+x setup.sh
 		sudo ./setup.sh -U
+		Log "UPDATE-JELLYMAN | Updated Jellyman from $jellymanVersion to v$currentJellymanVersion" $logFile
 	fi
 }
 
@@ -1164,13 +1277,15 @@ ChangeMediaDirectory()
 			if AreDirectories "$mediaPath"; then
 				continue=false
 				SetVar defaultPath "$mediaPath" "$sourceFile" array
+				Log "CHANGE-MEDIA-DIRECTORY | SetVar defaultPath $mediaPath $sourceFile" $logFile
 				exit
 			else
-				warning="ERROR: Make sure each input is a directory!"
+				warning="> ERROR: Make sure each input is a directory!"
 				exit
 			fi
 		else
 			SetVar defaultPath "$mediaPath" "$sourceFile" dir
+			Log "CHANGE-MEDIA-DIRECTORY | SetVar defaultPath $mediaPath $sourceFile" $logFile
 			exit
 		fi
 	done
@@ -1179,50 +1294,7 @@ ChangeMediaDirectory()
 Help()
 {
 	# Display Help
-	echo "Jellyman - The Jellyfin Manager $jellymanVersion"
-	echo "-Created by Smiley McSmiles"
-	echo
-	echo "Syntax: jellyman -[COMMAND] [PARAMETER]"
-	echo "COMMANDS:"
-	echo "-b, --backup                 [DIRECTORY] Input directory to output backup archive."
-	echo "-ba, --backup-auto           Perform an automatic backup."
-	echo "-bu, --backup-utility        Start the automatic backup utility."
-	echo "-d, --disable                Disable Jellyfin on System Start."
-	echo "-e, --enable                 Enable Jellyfin on System Start."
-	echo "-h, --help                   Print this Help."
-	echo "-i, --import                 [FILE.tar - optional] Input file to Import jellyfin-backup.tar."
-	echo "-p, --permissions            [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory."
-	echo "-r, --restart                Restart Jellyfin."
-	echo "-s, --start                  Start Jellyfin."
-	echo "-S, --stop                   Stop Jellyfin."
-	echo "-t, --status                 Status of Jellyfin."
-	echo "-u, --update-jellyfin        [URL - optional] Downloads and updates the current stable or supplied Jellyfin version."
-	echo "-U, --update-jellyman        Update Jellyman - The Jellyfin Manager."
-	echo "-ub, --update-beta           Update Jellyfin to the most recent Beta."
-	echo "-ls, --library-scan          Tell Jellyfin to scan your media library."
-	echo "-v, --version                Get the current installed version of Jellyfin."
-	echo "-vd, --version-download      Download an available Jellyfin version from the stable repository."
-	echo "-vs, --version-switch        Switch Jellyfin version for another previously installed version."
-	echo "-vr, --version-remove        Remove a Jellyfin version."
-	echo "-rc, --recertify             Removes old https certifications and creates new ones for the next 365 days."
-	echo "-rn, --rename                Batch renaming script for TV shows."
-	echo "-cp, --change-http           Change Jellyfins http network port - Default = 8096"
-	echo "-cps, --change-https         Change Jellyfins https network port - Default = 8920."
-	echo "-ik, --import-key            Import an API key"
-	echo "-md, --media-directory       Change the Media Directory for Jellyman."
-	echo "-tc, --transcode             Transcode a file/directory with a GB per hour filter (1.5GB is recommended)"
-	echo "-tcp, --transcode-progress   View progress of the Transcode"
-	echo "-tcs, --transcode-stop       Stop the current transcode process."
-	echo "-X, --uninstall              Uninstall Jellyfin and Jellyman Completely."
-	echo
-	echo "To browse Jellyfin archives please use this link."
-	echo "https://repo.jellyfin.org/files/server/linux/stable/"
-	echo
-	echo "EXAMPLE:"
-	echo "- To stop jellyfin, disable on startup, and then get status of the jellyfin service:"
-	echo '├── "sudo jellyman --stop --disable --status"'
-	echo '└── "sudo jellyman -S -d -t"'
-
+	echo "$helpList"
 }
 
 ###############################################################################
@@ -1241,8 +1313,12 @@ if [ -n "$1" ]; then
 				 shift ;;
 			-ba | --backup-auto) BackupAuto ;;
 			-bu | --backup-utility) BackupUtility ;;
-			-d | --disable) systemctl disable jellyfin.service ;;
-			-e | --enable) systemctl enable jellyfin.service ;;
+			-d | --disable) HasSudo
+						systemctl disable jellyfin.service
+						Log "JELLYMAN | Disabled Jellyfin" $logFile ;;
+			-e | --enable) HasSudo
+						systemctl enable jellyfin.service
+						Log "JELLYMAN | Enabled Jellyfin" $logFile ;;
 			-h | --help) Help ;;
 			-i | --import) Import "$2"
 				 shift ;;
@@ -1252,9 +1328,15 @@ if [ -n "$1" ]; then
 					 Permissions $2
 					 shift 
 				 fi ;;
-			-r | --restart) systemctl restart jellyfin.service ;;
-			-s | --start) systemctl start jellyfin.service ;;
-			-S | --stop) systemctl stop jellyfin.service ;;
+			-r | --restart) HasSudo
+						systemctl restart jellyfin.service
+						Log "JELLYMAN | Restarted Jellyfin" $logFile ;;
+			-s | --start) HasSudo
+						systemctl start jellyfin.service
+						Log "JELLYMAN | Started Jellyfin" $logFile ;;
+			-S | --stop) HasSudo
+						systemctl stop jellyfin.service
+						Log "JELLYMAN | Stopped Jellyfin" $logFile ;;
 			-t | --status) Status ;;
 			-u | --update-jellyfin) if [[ "$2" == "-"* ]]; then
 					 Update
@@ -1267,9 +1349,10 @@ if [ -n "$1" ]; then
 			-ub | --update-beta) UpdateBeta ;;
 			-v | --version) GetJellyfinVersion
 					GetJellymanVersion ;;
-			-vd | --version-download) DownloadVersion ;;
+			-vd | --version-download) VersionDownload ;;
 			-vs | --version-switch) VersionSwitch ;;
-			-vr | --version-remove) RemoveVersion ;;
+			-vr | --version-remove) VersionRemove ;;
+			-vl | --view-log) ViewLog;;
 			-rc | --recertify) RecertifyHttps ;;
 			-rn | --rename) RenameTv ;;
 			-ls | --library-scan) LibraryScan ;;

--- a/setup.sh
+++ b/setup.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 DIRECTORY=$(cd `dirname $0` && pwd)
 source $DIRECTORY/scripts/base_functions.sh
-has_sudo_access=
+hasSudoAccess=
 architecture=
-os_detected=
+osDetected=
 currentJellyfinDirectory=null
 tarPath=
 sourceFile=/opt/jellyfin/config/jellyman.conf
 
 Import()
 {
-	Prompt_user dir "> Please enter the directory to the jellyfin-backup.tar archive(s)." 0 0 "/path/to/backup(s)"
+	PromptUser dir "> Please enter the directory to the jellyfin-backup.tar archive(s)." 0 0 "/path/to/backup(s)"
 	importDir=$promptDir
 	listOfBackups=$(ls -1 $importDir | grep "jellyfin-backup".*".tar")
 	listOfBackupsNumbered=$(echo "$listOfBackups" | cat -n)
 	numberOfBackups=$(echo "$listOfBackups" | wc -l)
 	echo "$listOfBackupsNumbered"
-	Prompt_user num "> Please enter the number corresponding with the archive you wish to import." 1 $numberOfBackups "1-$numberOfBackups"
+	PromptUser num "> Please enter the number corresponding with the archive you wish to import." 1 $numberOfBackups "1-$numberOfBackups"
 	backupToImportNumber=$promptNum
 	backupToImport=$(echo "$listOfBackups" | head -n $backupToImportNumber | tail -n 1)
 	importTar="$importDir/$backupToImport"
@@ -26,7 +26,7 @@ Import()
 	echo "|      This import procedurewill erase /opt/jellyfin COMPLETELY      |"
 	echo "+--------------------------------------------------------------------+"
 
-	if Prompt_user yN "> Import $importTar?"; then
+	if PromptUser yN "> Import $importTar?"; then
 		echo "> IMPORTING $importTar"
 		
 		if [[ -d /opt/jellyfin ]]; then
@@ -43,12 +43,12 @@ Import()
 		
 		if [ -d /usr/lib/systemd/system ]; then
 			jellyfinServiceLocation="/usr/lib/systemd/system"
-			Set_var jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
+			SetVar jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
 			mv -f /opt/jellyfin/backup/*.service /usr/lib/systemd/system/
 			mv -f /opt/jellyfin/backup/jellyfin-backup.timer /usr/lib/systemd/system/
 		else
 			jellyfinServiceLocation="/etc/systemd/system"
-			Set_var jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
+			SetVar jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
 			mv -f /opt/jellyfin/backup/*.service /etc/systemd/system/
 			mv -f /opt/jellyfin/backup/jellyfin-backup.timer /etc/systemd/system/
 		fi
@@ -58,21 +58,21 @@ Import()
 		if [[ -n $autoBackups ]] && $autoBackups; then
 			systemctl enable --now jellyfin-backup.timer
 		else
-			if Prompt_user Yn "Enable automatic backups?" 0 0 "Y/n"; then
+			if PromptUser Yn "Enable automatic backups?" 0 0 "Y/n"; then
 				systemctl enable --now jellyfin-backup.timer
-				Set_var autoBackups true "$sourceFile" str
-				Set_var "backupFrequency" "weekly" "$sourceFile"
+				SetVar autoBackups true "$sourceFile" str
+				SetVar "backupFrequency" "weekly" "$sourceFile"
 			else
 				systemctl enable --now jellyfin-backup.timer
-				Set_var autoBackups false "$sourceFile" str
-				Set_var "backupFrequency" "weekly" "$sourceFile"
+				SetVar autoBackups false "$sourceFile" str
+				SetVar "backupFrequency" "weekly" "$sourceFile"
 			fi
 		fi
 		
 		if id $defaultUser &>/dev/null; then 
 			chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 			chmod -Rf 770 /opt/jellyfin
-			Install_dependencies
+			InstallDependencies
 			jellyman -e -s
 			echo "> IMPORT COMPLETE!"
 		else
@@ -85,15 +85,15 @@ Import()
 			echo "|                   You may want to see who owns that configuration file with:                  |"
 			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
 			echo "+-----------------------------------------------------------------------------------------------+"
-			if Prompt_user yN "> Would you like to create the LINUX user $defaultUser?"; then
+			if PromptUser yN "> Would you like to create the LINUX user $defaultUser?"; then
 				echo "> Great!"
 				useradd -rd /opt/jellyfin $defaultUser
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
-				Install_dependencies
+				InstallDependencies
 				jellyman -e -s -t
 			else
-				Prompt_user usr "> Please enter a new LINUX user" 0 0 "jellyfin"
+				PromptUser usr "> Please enter a new LINUX user" 0 0 "jellyfin"
 				defaultUser=$promptUsr
 		 
 				defaultUser=${defaultUser,,}
@@ -102,7 +102,7 @@ Import()
 				
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
-				Install_dependencies
+				InstallDependencies
 				jellyman -e -s -t
 			fi
 		fi
@@ -131,7 +131,7 @@ Import()
 		echo "+-------------------------------------------------------------------+"
 	fi
 	
-	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+	if PromptUser Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
 		echo "> Removing cloned git directory: $DIRECTORY..."
 		rm -rf $DIRECTORY
 	else
@@ -139,7 +139,7 @@ Import()
 	fi
 }
 
-Get_Architecture()
+GetArchitecture()
 {
 	cpuArchitectureFull=$(uname -m)
 		case "$cpuArchitectureFull" in
@@ -151,7 +151,7 @@ Get_Architecture()
 		esac
 }
 
-Install_dependencies()
+InstallDependencies()
 {
 	packagesNeededDebian='ffmpeg git net-tools openssl bc screen curl'
 	packagesNeededRHEL='ffmpeg ffmpeg-devel ffmpeg-libs git openssl bc screen curl'
@@ -162,7 +162,7 @@ Install_dependencies()
 	if [ -f /etc/os-release ]; then
 		source /etc/os-release
 		crbOrPowertools=
-		os_detected=true
+		osDetected=true
 		echo "> ID=$ID"
 		
 		if [[ $ID_LIKE == .*"rhel".* ]] || [[ $ID == "rhel" ]]; then
@@ -196,7 +196,7 @@ Install_dependencies()
 				opensuse*) zypper install $packagesNeededOpenSuse ;;
 			esac
 	else
-		os_detected=false
+		osDetected=false
 		echo "+-------------------------------------------------------------------+"
 		echo "|                       ******WARNING******                         |"
 		echo "|                        ******ERROR******                          |"
@@ -229,15 +229,15 @@ Backup()
 }
 
 
-Previous_install()
+PreviousInstall()
 {
 	echo "> WARNING: THIS OPTION IS HIGHLY UNSTABLE, ONLY USE IF YOU KNOW WHAT YOU'RE DOING!!!"
 	echo
-	if Prompt_user yN "> Is Jellyfin CURRENTLY installed on this system?"; then
+	if PromptUser yN "> Is Jellyfin CURRENTLY installed on this system?"; then
 		isDataThere=false
 		isConfigThere=false
 		newDirectory=false
-		Prompt_user dir "> Where is Jellyfins intalled directory?" 0 0 "/path/to/jellyfin/dir"
+		PromptUser dir "> Where is Jellyfins intalled directory?" 0 0 "/path/to/jellyfin/dir"
 		currentJellyfinDirectory=$promptDir
 		
 		#systemFileXML=$(find $currentJellyfinDirectory -name "system.xml")
@@ -268,7 +268,7 @@ Previous_install()
 		
 		if ! $isDataThere || ! $isConfigThere; then
 			echo "***ERROR*** - one or more directories not found..."
-			if Prompt_user Yn "> Would you like to try a different directory?"; then
+			if PromptUser Yn "> Would you like to try a different directory?"; then
 				currentJellyfinDirectory=null
 			else
 				exit
@@ -286,7 +286,7 @@ Previous_install()
 Setup()
 {
 	echo "> Fetching newest stable Jellyfin version..."
-	Get_Architecture
+	GetArchitecture
 	jellyfin=
 	jellyfin_archive=
 	
@@ -301,12 +301,12 @@ Setup()
 	
 	mkdir /opt/jellyfin /opt/jellyfin/old /opt/jellyfin/backup /opt/jellyfin/data /opt/jellyfin/cache /opt/jellyfin/config /opt/jellyfin/log /opt/jellyfin/cert
 	clear
-	Previous_install
-	Prompt_user usr "> Please enter the LINUX user for Jellyfin" 0 0 "jellyfin"
+	PreviousInstall
+	PromptUser usr "> Please enter the LINUX user for Jellyfin" 0 0 "jellyfin"
 	defaultUser=$promptUsr
 	while id "$defaultUser" &>/dev/null; do
 		echo "> Cannot create $defaultUser as $defaultUser already exists..."
-		Prompt_user usr "> Please re-enter a new LINUX user for Jellyfin"
+		PromptUser usr "> Please re-enter a new LINUX user for Jellyfin"
 		defaultUser=$promptUsr
 	done
 	
@@ -337,7 +337,7 @@ Setup()
 		jellyfinServiceLocation="/etc/systemd/system"
 	fi
 	
-	Set_var User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
+	SetVar User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
 	cp $DIRECTORY/conf/jellyfin.conf /etc/
 	jellyfinDir=/opt/jellyfin
 	jellyfinConfigFile=$jellyfinDir/config/jellyman.conf
@@ -345,15 +345,15 @@ Setup()
 	tar xzf $DIRECTORY/$jellyfin_archive
 	mv -f $DIRECTORY/jellyfin /opt/jellyfin/$jellyfin
 	ln -s $jellyfinDir/$jellyfin $jellyfinDir/jellyfin
-	Set_var architecture "$architecture" "$jellyfinConfigFile" str
-	Set_var httpPort "8096" "$jellyfinConfigFile" str
-	Set_var httpsPort "8920" "$jellyfinConfigFile" str
-	Set_var currentVersion "$jellyfin" "$jellyfinConfigFile" str
-	Set_var defaultUser "$defaultUser" "$jellyfinConfigFile" str
-	Set_var jellyfinServiceLocation "$jellyfinServiceLocation" "$jellyfinConfigFile" str
+	SetVar architecture "$architecture" "$jellyfinConfigFile" str
+	SetVar httpPort "8096" "$jellyfinConfigFile" str
+	SetVar httpsPort "8920" "$jellyfinConfigFile" str
+	SetVar currentVersion "$jellyfin" "$jellyfinConfigFile" str
+	SetVar defaultUser "$defaultUser" "$jellyfinConfigFile" str
+	SetVar jellyfinServiceLocation "$jellyfinServiceLocation" "$jellyfinConfigFile" str
 
 	echo "> Installing dependencies..."
-	Install_dependencies
+	InstallDependencies
 
 	echo "> Setting Permissions for Jellyfin..."
 	chown -R $defaultUser:$defaultUser /opt/jellyfin
@@ -378,7 +378,7 @@ Setup()
 		echo "+-------------------------------------------------------------------+"
 	fi
 
-	if $os_detected; then
+	if $osDetected; then
 		jellyman -e -s
 		echo
 		echo
@@ -414,7 +414,7 @@ Setup()
 	read -p "> Press ENTER to continue" ENTER
 	jellyman -t
 	echo
-	if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+	if PromptUser Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
 		echo "> Removing cloned git directory: $DIRECTORY..."
 		rm -rf $DIRECTORY
 	else
@@ -442,7 +442,7 @@ Update_jellyman()
 	# deletes all empty lines in $sourcefile
 	sed -i '/^ *$/d' $sourceFile
 	
-	Set_var User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
+	SetVar User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
 	
 	if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
 		cp $DIRECTORY/jellyman.1 /usr/share/man/man1/
@@ -451,18 +451,18 @@ Update_jellyman()
 	fi
 	
 	if ( ! grep -q httpPort= "$sourceFile" ) || ( ! grep -q httpsPort= "$sourceFile" ); then
-		Set_var httpPort "8096" "$sourceFile" str
-		Set_var httpsPort "8920" "$sourceFile" str
+		SetVar httpPort "8096" "$sourceFile" str
+		SetVar httpsPort "8920" "$sourceFile" str
 	fi
 	
-	Del_var networkPort $sourceFile
+	DelVar networkPort $sourceFile
 	
 	if [[ -d /usr/lib/systemd ]] && [[ ! -n $jellyfinServiceLocation ]]; then
 		jellyfinServiceLocation="/usr/lib/systemd/system"
-		Set_var jellyfinServiceLocation "$jellyfinServiceLocation" "$sourceFile" str
+		SetVar jellyfinServiceLocation "$jellyfinServiceLocation" "$sourceFile" str
 	elif [[ ! -n $jellyfinServiceLocation ]]; then
 		jellyfinServiceLocation="/etc/systemd/system"
-		Set_var jellyfinServiceLocation "$jellyfinServiceLocation" "$sourceFile" str
+		SetVar jellyfinServiceLocation "$jellyfinServiceLocation" "$sourceFile" str
 	fi
 	
 	cp $DIRECTORY/conf/jellyfin.service $jellyfinServiceLocation/
@@ -475,15 +475,15 @@ Update_jellyman()
 	
 	if [[ ! -n $architecture ]]; then
 		architecture=
-		Get_Architecture
-		Set_var architecture "$architecture" "$sourceFile" str
+		GetArchitecture
+		SetVar architecture "$architecture" "$sourceFile" str
 	fi
 
 	if [[ $_skip == "y" ]]; then
 		echo "> Removing cloned git directory: $DIRECTORY..."
 		rm -rf $DIRECTORY
 	else
-		if Prompt_user Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
+		if PromptUser Yn "> Would you like to remove the cloned git directory $DIRECTORY?"; then
 			echo "> Removing cloned git directory: $DIRECTORY..."
 			rm -rf $DIRECTORY
 		else
@@ -494,7 +494,7 @@ Update_jellyman()
 	
 }
 
-Has_sudo
+HasSudo
 optionNumber=
 
 if [[ $1 == "-U" ]]; then
@@ -505,7 +505,7 @@ else
 		echo "2. Force update Jellyman"
 		echo "3. Import a jellyfin-backup.tar file"
 		echo
-		Prompt_user num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
+		PromptUser num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
 		optionNumber=$promptNum
 		echo
 	done

--- a/setup.sh
+++ b/setup.sh
@@ -10,20 +10,25 @@ sourceFile=/opt/jellyfin/config/jellyman.conf
 
 Import()
 {
+	logFile=/tmp/jellyman_import.log
+	touch $logFile
 	PromptUser dir "> Please enter the directory to the jellyfin-backup.tar archive(s)." 0 0 "/path/to/backup(s)"
-	importDir=$promptDir
+	importDir=$promptResult
+	Log "IMPORT | importDir=$promptResult" $logFile
 	listOfBackups=$(ls -1 $importDir | grep "jellyfin-backup".*".tar")
 	listOfBackupsNumbered=$(echo "$listOfBackups" | cat -n)
 	numberOfBackups=$(echo "$listOfBackups" | wc -l)
 	echo "$listOfBackupsNumbered"
 	PromptUser num "> Please enter the number corresponding with the archive you wish to import." 1 $numberOfBackups "1-$numberOfBackups"
-	backupToImportNumber=$promptNum
+	backupToImportNumber=$promptResult
 	backupToImport=$(echo "$listOfBackups" | head -n $backupToImportNumber | tail -n 1)
 	importTar="$importDir/$backupToImport"
+	Log "IMPORT | importTar=$importDir/$backupToImport" $logFile
+	jellyfinServiceLocation=
 
 	echo "+--------------------------------------------------------------------+"
 	echo "|                        ******CAUTION******                         |"
-	echo "|      This import procedurewill erase /opt/jellyfin COMPLETELY      |"
+	echo "|      This import procedure will erase /opt/jellyfin COMPLETELY      |"
 	echo "+--------------------------------------------------------------------+"
 
 	if PromptUser yN "> Import $importTar?"; then
@@ -31,10 +36,13 @@ Import()
 		
 		if [[ -d /opt/jellyfin ]]; then
 			rm -rf /opt/jellyfin
+			Log "IMPORT | Removed /opt/jellyfin" $logFile
 		fi
 		
 		tar xf $importTar -C /
 		source $sourceFile
+		mv -f $logFile /opt/jellyfin/log/
+		logFile=/opt/jellyfin/jellyman_import.log
 		mv -f /opt/jellyfin/backup/jellyfin.conf /etc/
 		cp -f $DIRECTORY/scripts/jellyman /usr/bin/
 		cp -f $DIRECTORY/scripts/base_functions.sh /usr/bin/
@@ -44,14 +52,15 @@ Import()
 		if [ -d /usr/lib/systemd/system ]; then
 			jellyfinServiceLocation="/usr/lib/systemd/system"
 			SetVar jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
-			mv -f /opt/jellyfin/backup/*.service /usr/lib/systemd/system/
-			mv -f /opt/jellyfin/backup/jellyfin-backup.timer /usr/lib/systemd/system/
+			mv -f /opt/jellyfin/backup/*.service $jellyfinServiceLocation/
+			mv -f /opt/jellyfin/backup/jellyfin-backup.timer $jellyfinServiceLocation/
 		else
 			jellyfinServiceLocation="/etc/systemd/system"
 			SetVar jellyfinServiceLocation $jellyfinServiceLocation "$sourceFile" str
 			mv -f /opt/jellyfin/backup/*.service /etc/systemd/system/
 			mv -f /opt/jellyfin/backup/jellyfin-backup.timer /etc/systemd/system/
 		fi
+		Log "IMPORT | SetVar jellyfinServiceLocation=$jellyfinServiceLocation" $logFile
 		
 		systemctl daemon-reload
 		
@@ -75,34 +84,36 @@ Import()
 			InstallDependencies
 			jellyman -e -s
 			echo "> IMPORT COMPLETE!"
+			Log "IMPORT | Complete!" $logFile
 		else
-			clear
-			echo "+-----------------------------------------------------------------------------------------------+"
-			echo "|                                     *******ERROR*******                                       |"
-			echo "|          The imported default Jellyfin user($defaultUser) has not yet been created.           |"
-			echo "|              This error is likely due to a read error of the $sourceFile file.                |"
-			echo "| The default user is usually created by Jellyman - The Jellyfin Manager, when running setup.sh.|"
-			echo "|                   You may want to see who owns that configuration file with:                  |"
-			echo "|                          'ls -l /opt/jellyfin/config/jellyman.conf'                           |"
-			echo "+-----------------------------------------------------------------------------------------------+"
-			if PromptUser yN "> Would you like to create the LINUX user $defaultUser?"; then
-				echo "> Great!"
+			echo
+			echo "> The imported LINUX user for Jellyfin has not yet been created."
+			if PromptUser yN "> Would you like to create the imported LINUX user $defaultUser?"; then
+				echo "> Creating LINUX user $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
+				Log "IMPORT | Useradd $defaultUser" $logFile
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
+				SetVar User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
 				InstallDependencies
 				jellyman -e -s -t
 			else
-				PromptUser usr "> Please enter a new LINUX user" 0 0 "jellyfin"
-				defaultUser=$promptUsr
-		 
-				defaultUser=${defaultUser,,}
-				echo "> Linux user = $defaultUser"
+				PromptUser usr "> Please enter a new LINUX user." 0 0 "jellyfin"
+				defaultUser=$promptResult
+				while id "$defaultUser" &>/dev/null; do
+					echo "> Cannot create $defaultUser as $defaultUser already exists..."
+					PromptUser usr "> Please re-enter a new default LINUX user for Jellyfin"
+					defaultUser=$promptResult
+					Log "ERROR | IMPORT | USERADD FAILED $defaultUser ALREADY EXISTS" $logFile
+				done
+
+				echo "> LINUX user = $defaultUser"
 				useradd -rd /opt/jellyfin $defaultUser
-				
+				Log "IMPORT | Useradd $defaultUser" $logFile
 				chown -Rf $defaultUser:$defaultUser /opt/jellyfin
 				chmod -Rf 770 /opt/jellyfin
 				InstallDependencies
+				SetVar User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
 				jellyman -e -s -t
 			fi
 		fi
@@ -115,14 +126,17 @@ Import()
 
 	echo "> Unblocking port $httpPort and $httpsPort..."
 	if [ -x "$(command -v ufw)" ]; then
+		Log "IMPORT | Using ufw to unblock $httpPort AND $httpsPort" $logFile
 		ufw allow $httpPort/tcp
 		ufw allow $httpsPort/tcp
 		ufw reload
 	elif [ -x "$(command -v firewall-cmd)" ]; then
+		Log "IMPORT | Using firewalld to unblock $httpPort AND $httpsPort" $logFile
 		firewall-cmd --permanent --add-port=$httpPort/tcp
 		firewall-cmd --permanent --add-port=$httpsPort/tcp
 		firewall-cmd --reload
 	else
+		Log "ERROR | IMPORT | UNABLE TO FIND UFW OR FIREWALLD" $logFile
 		echo "+-------------------------------------------------------------------+"
 		echo "|                        ******WARNING******                        |"
 		echo "|                         ******ERROR******                         |"
@@ -238,7 +252,7 @@ PreviousInstall()
 		isConfigThere=false
 		newDirectory=false
 		PromptUser dir "> Where is Jellyfins intalled directory?" 0 0 "/path/to/jellyfin/dir"
-		currentJellyfinDirectory=$promptDir
+		currentJellyfinDirectory=$promptResult
 		
 		#systemFileXML=$(find $currentJellyfinDirectory -name "system.xml")
 		#configPath=$(echo $systemFileXML | sed -r "s|/system.xml||g")
@@ -285,6 +299,7 @@ PreviousInstall()
 
 Setup()
 {
+	logFile=/tmp/jellyman_setup.log
 	echo "> Fetching newest stable Jellyfin version..."
 	GetArchitecture
 	jellyfin=
@@ -294,25 +309,29 @@ Setup()
 		jellyfin_archive=$(curl -sL https://repo.jellyfin.org/files/server/linux/latest-stable/$architecture/ | grep -Po jellyfin_[^_]+-$architecture.tar.gz | head -1)	
 		wget https://repo.jellyfin.org/files/server/linux/latest-stable/$architecture/$jellyfin_archive
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|-$architecture.tar.gz||g")
+		Log "SETUP | Downloaded https://repo.jellyfin.org/files/server/linux/latest-stable/$architecture/$jellyfin_archive" $logFile
 	else
 		jellyfin_archive=$(ls *.tar.gz)
 		jellyfin=$(echo $jellyfin_archive | sed -r "s|-$architecture.tar.gz||g")
+		Log "SETUP | Using local $jellyfin_archive" $logFile
 	fi
 	
 	mkdir /opt/jellyfin /opt/jellyfin/old /opt/jellyfin/backup /opt/jellyfin/data /opt/jellyfin/cache /opt/jellyfin/config /opt/jellyfin/log /opt/jellyfin/cert
+	mv $logFile /opt/jellyfin/log
+	logFile=/opt/jellyfin/log/jellyman_setup.log
 	clear
 	PreviousInstall
 	PromptUser usr "> Please enter the LINUX user for Jellyfin" 0 0 "jellyfin"
-	defaultUser=$promptUsr
+	defaultUser=$promptResult
 	while id "$defaultUser" &>/dev/null; do
 		echo "> Cannot create $defaultUser as $defaultUser already exists..."
 		PromptUser usr "> Please re-enter a new LINUX user for Jellyfin"
-		defaultUser=$promptUsr
+		defaultUser=$promptResult
 	done
 	
-	defaultUser=${defaultUser,,}
 	echo "> Linux user = $defaultUser"
 	useradd -rd /opt/jellyfin $defaultUser
+	Log "SETUP | Created user $defaultUser" $logFile
 
 	if [ -x "$(command -v apt)" ] || [ -x "$(command -v pacman)" ]; then
 		cp $DIRECTORY/jellyman.1 /usr/share/man/man1/
@@ -336,8 +355,10 @@ Setup()
 		cp $DIRECTORY/conf/jellyfin-backup* /etc/systemd/system/
 		jellyfinServiceLocation="/etc/systemd/system"
 	fi
+	Log "SETUP | SetVar jellyfinServiceLocation=$jellyfinServiceLocation" $logFile
 	
 	SetVar User "$defaultUser" "$jellyfinServiceLocation/jellyfin.service" str
+	Log "SETUP | SetVar User to $defaultUser in $jellyfinServiceLocation/jellyfin.service" $logFile
 	cp $DIRECTORY/conf/jellyfin.conf /etc/
 	jellyfinDir=/opt/jellyfin
 	jellyfinConfigFile=$jellyfinDir/config/jellyman.conf
@@ -351,6 +372,7 @@ Setup()
 	SetVar currentVersion "$jellyfin" "$jellyfinConfigFile" str
 	SetVar defaultUser "$defaultUser" "$jellyfinConfigFile" str
 	SetVar jellyfinServiceLocation "$jellyfinServiceLocation" "$jellyfinConfigFile" str
+	Log "SETUP | SetVar $architecture 8096 8920 $jellyfin $defaultUser $jellyfinServiceLocation" $logFile
 
 	echo "> Installing dependencies..."
 	InstallDependencies
@@ -365,11 +387,14 @@ Setup()
 		ufw allow 8096/tcp
 		ufw allow 8920/tcp
 		ufw reload
+		Log "SETUP | Used ufw to allow ports 8096 and 8920" $logFile
 	elif [ -x "$(command -v firewall-cmd)" ]; then
 		firewall-cmd --permanent --add-port=8096/tcp
 		firewall-cmd --permanent --add-port=8920/tcp
 		firewall-cmd --reload
+		Log "SETUP | Used firewalld to allow ports 8096 and 8920" $logFile
 	else
+		Log "ERROR | SETUP | FAILED TO OPEN PORT 8096/8920! NO UFW OR FIREWALLD FOUND" $logFile
 		echo "+-------------------------------------------------------------------+"
 		echo "|                        ******WARNING******                        |"
 		echo "|                         ******ERROR******                         |"
@@ -379,6 +404,7 @@ Setup()
 	fi
 
 	if $osDetected; then
+		Log "SETUP | DONE" $logFile
 		jellyman -e -s
 		echo
 		echo
@@ -399,6 +425,7 @@ Setup()
 		read -p "Press ENTER to continue" ENTER
 		jellyman -h
 	else
+		Log "ERROR | SETUP | NO /etc/os-release FILE!" $logFile
 		jellyman -h 
 		echo "+-------------------------------------------------------------------+"
 		echo "|                        ******WARNING******                        |"
@@ -424,7 +451,11 @@ Setup()
 
 Update_jellyman()
 {
+	logFile=/opt/jellyfin/log/jellyman_update.log
+
 	if [[ ! -f /usr/bin/jellyman ]]; then
+		logFile=/tmp/jellyman_update.log
+		Log "ERROR | UPDATE | JELLYMAN NOT INSTALLED" $logFile
 		echo "> ERROR: JELLYMAN IS NOT INSTALLED, CANNOT UPDATE."
 		echo "> Please run 'sudo ./setup.sh' and choose option #1" 
 		return 1
@@ -433,6 +464,7 @@ Update_jellyman()
 	_skip=$1
 	source $sourceFile
 	echo "> Updating Jellyman - The Jellyfin Manager"
+	Log "UPDATE | Jellyman started update" $logFile
 	cp -f $DIRECTORY/scripts/jellyman /usr/bin/jellyman
 	cp -f $DIRECTORY/scripts/jellyfin.sh /opt/jellyfin/jellyfin.sh
 	chmod +rx /usr/bin/jellyman
@@ -491,7 +523,7 @@ Update_jellyman()
 		fi
 	fi
 	echo "> ...complete"
-	
+	Log "UPDATE | Jellyman finished update" $logFile
 }
 
 HasSudo
@@ -506,7 +538,7 @@ else
 		echo "3. Import a jellyfin-backup.tar file"
 		echo
 		PromptUser num "> Please select the number corresponding with the option you want to select." 1 3 "1-3"
-		optionNumber=$promptNum
+		optionNumber=$promptResult
 		echo
 	done
 


### PR DESCRIPTION
## Additions
- `jellyman -vl` Choose from a list of logs to view.
- Jellyman now logs things during setup.sh and when using Jellyman. See /opt/jellyfin/log for details. Or use the new `jellyman -vl` to view those logs.
- Added option in `jellyman -bu` to initiate a backup.

## Fixes
- Typos in `jellyan -i` and `setup.sh` import
- Fixed Jellyfin Linux user mismatch on import not changing User variable in the jellyfin.service file
- `jellyman -vr` would allow the user to remove the current version of Jellyfin.
- `jellyman -vd` would allow the user to download the current version of Jellyfin.

## Changes
 - All functions are now Pascal Case