### PR TITLE
Add files via upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG.md for https://GitHub.com/Smiley-McSmiles/jellyman
 
+# Jellyman v1.9.2
+## Changes
+- setup.sh no longer has an option to migrate data from one install to another install.
+ - This option has caused a lot of headache to get to work correctly. If you are a BASH programmer, please feel free to post a pull request to add this _feature_ back in (If you can get migrating to work reliably across many different types of jellyfin installs)
+
 # Jellyman v1.9.1
 ## Additions
 - Added fail safe for deleting files during transcode, to make sure to not delete files if the transcode failed for any reason.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.9.1 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.9.2 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34-40, Ubuntu 22.04-24.04, Manjaro 21.3.6, EndeavourOS Artemis Neo/Nova/Cassini Nova, Linux Mint 21, and Rocky/Alma/RHEL Linux 8.6/9.0
 
@@ -24,61 +24,6 @@ cd ~/
 # Features
 
 * **Setup** - Sets up the initial install.
-* **Import Metadata and Configuration** - During setup, import the **CURRENTLY** installed Jellyfin configs and metadata.
-```
-   ├── NOTE - If you installed Jellyfin with Docker
-   ├── this will likely not work
-   └── Assumes your directory structure is similar to a bare metal install.
-```
-**For example in your Jellyfin directory it should look like this:**
-```
-/path/jellyfin
-      ├── cache
-      │   ├── audiodb-album
-      │   ├── audiodb-artist
-      │   ├── extracted-audio-images
-      │   ├── images
-      │   ├── imagesbyname
-      │   ├── omdb
-      │   └── temp
-      ├── config
-      │   ├── branding.xml
-      │   ├── dlna
-      │   ├── encoding.xml
-      │   ├── jellyman.conf
-      │   ├── logging.default.json
-      │   ├── metadata.xml
-      │   ├── migrations.xml
-      │   ├── network.xml
-      │   ├── system.xml
-      │   └── users
-      └── data
-          ├── data
-          │   ├── authentication.db
-          │   ├── authentication.db-journal
-          │   ├── jellyfin.db
-          │   ├── jellyfin.db-shm
-          │   ├── jellyfin.db-wal
-          │   ├── library.db
-          │   ├── library.db-journal
-          │   └── ScheduledTasks
-          ├── metadata
-          ├── plugins
-          ├── root
-          │   └── default
-          │       ├── Movies
-          │       │   ├── Movies111.mblink
-          │       │   ├── Movies11.mblink
-          │       │   ├── movies.collection
-          │       │   └── options.xml
-          │       └── TV Shows
-          │           ├── options.xml
-          │           ├── TV1.mblink
-          │           ├── TV.mblink
-          │           └── tvshows.collection
-          │
-          └── transcodes
-```
 * **Update** - [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
 ```
     └── NOTE - Supplied URL has to be formatted like: jellyfin_x.x.x-<ARCHITECTURE>.tar.gz

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.9.1
+.B Jellyman - The Jellyfin Manager - v1.9.2
 
 .SH SYNOPSIS
 .B jellyman

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.9.1"
+jellymanVersion="v1.9.2"
 logDir=/opt/jellyfin/log
 logFile=$logDir/jellyman.log
 sourceFile="/opt/jellyfin/config/jellyman.conf"

--- a/setup.sh
+++ b/setup.sh
@@ -222,77 +222,6 @@ InstallDependencies(){
 	fi
 }
 
-Backup(){
-	backupDirectory=$1
-	fileName=current-jellyfin-data.tar
-	if [[ $(echo "${backupDirectory: -1}") == "/" ]]; then
-		tarPath=$backupDirectory$fileName
-		echo "> Saving your current metadata to --> $tarPath"
-	else
-		tarPath=$backupDirectory/$fileName
-		echo "> Saving your current metadata to --> $tarPath"
-	fi
-	
-	cd $currentJellyfinDirectory
-	time tar cvf $tarPath data config
-	USER=$(stat -c '%U' $backupDirectory)
-	chown -f $USER:$USER $tarPath
-	chmod -f 770 $tarPath
-}
-
-
-PreviousInstall(){
-	echo "> WARNING: THIS OPTION IS HIGHLY UNSTABLE, ONLY USE IF YOU KNOW WHAT YOU'RE DOING!!!"
-	echo
-	if PromptUser yN "> Is Jellyfin CURRENTLY installed on this system?"; then
-		isDataThere=false
-		isConfigThere=false
-		newDirectory=false
-		PromptUser dir "> Where is Jellyfins intalled directory?" 0 0 "/path/to/jellyfin/dir"
-		currentJellyfinDirectory=$promptResult
-		
-		#systemFileXML=$(find $currentJellyfinDirectory -name "system.xml")
-		#configPath=$(echo $systemFileXML | sed -r "s|/system.xml||g")
-		#metadataPath=$(grep -o "<MetadataPath>.*" $systemFileXML | sed -r "s|<MetadataPath>||g" | sed -r "s|</MetadataPath>||g")
-		#if [[ $configPath != *"config" ]]; then
-		#	echo "'config' folder not found"
-		#else
-		#	
-		#fi
-		
-		if [ ! -d "$currentJellyfinDirectory/data/metadata" ]; then
-			echo "$currentJellyfinDirectory/data/metadata does not exist"
-			isDataThere=false
-		else
-			isDataThere=true
-			echo "> Found metadata!"
-		fi
-
-		if [ ! -d "$currentJellyfinDirectory/config" ]; then
-			echo "$currentJellyfinDirectory/config does not exist"
-			isConfigThere=false
-		else
-			isConfigThere=true
-			echo "> Found config!"
-		fi
-
-		
-		if ! $isDataThere || ! $isConfigThere; then
-			echo "***ERROR*** - one or more directories not found..."
-			if PromptUser Yn "> Would you like to try a different directory?"; then
-				currentJellyfinDirectory=null
-			else
-				exit
-			fi
-		fi
-		
-		Backup $HOME
-		cd /opt/jellyfin
-		tar xf $tarPath -C ./
-	else
-		echo ""
-	fi
-}
 
 InstallJellyfinFfmpeg(){
 	logFile=$1
@@ -329,7 +258,6 @@ Setup(){
 	mv $logFile /opt/jellyfin/log
 	logFile=/opt/jellyfin/log/jellyman_setup.log
 	clear
-	PreviousInstall
 	PromptUser usr "> Please enter the LINUX user for Jellyfin" 0 0 "jellyfin"
 	defaultUser=$promptResult
 	while id "$defaultUser" &>/dev/null; do


### PR DESCRIPTION
## Changes
- setup.sh no longer has an option to migrate data from one install to another install.
 - This option has caused a lot of headache to get to work correctly. If you are a BASH programmer, please feel free to post a pull request to add this _feature_ back in (If you can get migrating to work reliably across many different types of jellyfin installs)