### PR TITLE
Jellyman v1.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG.md for https://GitHub.com/Smiley-McSmiles/jellyman
 
+# Jellyman v1.9.4
+## Changes
+- jellyman.log now keeps 5000 lines instead of 1000.
+- Updated the `--help` command.
+- Changed some laguage outputs.
+- Added help info for `less` command (`jellyman -vl`)
+
+## Additions 
+- `-sm,  --search-media         Search Media in your media directory/directories.`
+- `-lm,  --list-media           Provide a tree list of all media (output saved to /tmp/media.txt).`
+
+# Jellyman v1.9.3
+## Fixes
+- Fixed issue with jellyfin.service during setup.
+
 # Jellyman v1.9.2
 ## Changes
 - setup.sh no longer has an option to migrate data from one install to another install.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![jellyman](.github/banner-shadow.png?raw=true "Jellyman Logo")
 =======
 
-> v1.9.3 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
+> v1.9.4 - A Jellyfin Manager for the Jellyfin generic linux amd64, arm64, and armhf tar.gz packages
 
 > Tested on Fedora 34-40, Ubuntu 22.04-24.04, Manjaro 21.3.6, EndeavourOS Artemis Neo/Nova/Cassini Nova, Linux Mint 21, and Rocky/Alma/RHEL Linux 8.6/9.0
 
@@ -68,6 +68,8 @@ cd ~/
     └── Provides a list of currently installed versions of Jellyfin for you to switch to.
 ```
 * **View Logs** - Select from a list of logs to view.
+* **Search Media** - Search Media in your media directory/directories.
+* **List Media** - Provide a tree list of all media (output saved to /tmp/media.txt).
 * **Recertify https** - Removes old https certifications and creates new **self signed** keys for the next 365 days. 
 * **Rename TV** - Batch renaming script for TV shows.
 * **Library Scan** - Tell Jellyfin to scan your media library.
@@ -170,36 +172,39 @@ Jellyman - The Jellyfin Manager
 Syntax: jellyman -[COMMAND] [PARAMETER]
 
 COMMANDS:
--b, --backup                 [DIRECTORY] Input directory to output backup archive.
--ba, --backup-auto           Perform an automatic backup.
--bu, --backup-utility        Start the automatic backup utility.
--d, --disable                Disable Jellyfin on System Start.
--e, --enable                 Enable Jellyfin on System Start.
--h, --help                   Print this Help.
--i, --import                 [FILE.tar - optional] Input file to Import jellyfin-backup.tar.
--p, --permissions            [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory.
--r, --restart                Restart Jellyfin.
--s, --start                  Start Jellyfin.
--S, --stop                   Stop Jellyfin.
--t, --status                 Status of Jellyfin.
--u, --update-jellyfin        [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
--U, --update-jellyman        Update Jellyman - The Jellyfin Manager.
--ub, --update-beta           Update Jellyfin to the most recent Beta.
--v, --version                Get the current installed version of Jellyfin.
--vd, --version-download      Download an available Jellyfin version from the stable repository.
--vs, --version-switch        Switch Jellyfin version for another previously installed version.
--rv, --remove-version        Remove a Jellyfin version.
--rc, --recertify             Removes old https certifications and creates new ones for the next 365 days.
--rn, --rename                Batch renaming script for TV shows.
--ls, --library-scan          Tell Jellyfin to scan your media library.
--cp, --change-http           Change Jellyfins http network port - Default = 8096.
+-b,   --backup               [DIRECTORY] Input directory to output backup archive.
+-ba,  --backup-auto          Perform an automatic backup.
+-bu,  --backup-utility       Start the automatic backup utility.
+-d,   --disable              Disable Jellyfin on System Start.
+-e,   --enable               Enable Jellyfin on System Start.
+-h,   --help                 Print this Help.
+-i,   --import               Display list of backup .tar files to Import and automatically restores the selected backup.
+-p,   --permissions          [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory.
+-r,   --restart              Restart Jellyfin.
+-s,   --start                Start Jellyfin.
+-S,   --stop                 Stop Jellyfin.
+-t,   --status               Status of Jellyfin.
+-sm,  --search-media         Search Media in your media directory/directories.
+-lm,  --list-media           Provide a tree list of all media (output saved to /tmp/media.txt).
+-u,   --update-jellyfin      [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
+-U,   --update-jellyman      Update Jellyman - The Jellyfin Manager.
+-ub,  --update-beta          Update Jellyfin to the most recent Beta.
+-ls,  --library-scan         Tell Jellyfin to scan your media library.
+-v,   --version              Get the current installed version of Jellyfin.
+-vd,  --version-download     Download an available Jellyfin version from the stable repository.
+-vs,  --version-switch       Switch Jellyfin version for another previously installed version.
+-vr,  --version-remove       Remove a Jellyfin version.
+-vl   --view-log             Choose from a list of logs to view.
+-rc,  --recertify            Removes old https certifications and creates new ones for the next 365 days.
+-rn,  --rename               Batch renaming script for TV shows.
+-cp,  --change-http          Change Jellyfins http network port - Default = 8096.
 -cps, --change-https         Change Jellyfins https network port - Default = 8920.
--ik, --import-key            Import an API key
--md, --media-directory       Change the Media Directory for Jellyman.
--tc, --transcode             Transcode a file/directory with a GB per hour filter (1.5GB is recommended).
+-ik,  --import-key           Import a Jellyfin API key (Needed for `-ls` command).
+-md,  --media-directory      Change the Media Directory for Jellyman.
+-tc,  --transcode            Transcode a file/directory with a GB per hour filter (1.5GB is recommended).
 -tcp, --transcode-progress   View progress of the Transcode.
 -tcs, --transcode-stop       Stop the current transcode process.
--X, --uninstall              Uninstall Jellyfin and Jellyman Completely.
+-X,   --uninstall            Uninstall Jellyfin and Jellyman Completely.
 
 EXAMPLE:
 - To stop jellyfin, disable on startup, and then get status of the jellyfin service:

--- a/jellyman.1
+++ b/jellyman.1
@@ -7,7 +7,7 @@
 .B Jellyman - a Jellyfin Manager for the Jellyfin generic linux amd64.tar.gz package
 
 .SH VERSION
-.B Jellyman - The Jellyfin Manager - v1.9.3
+.B Jellyman - The Jellyfin Manager - v1.9.4
 
 .SH SYNOPSIS
 .B jellyman
@@ -40,7 +40,7 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .TP
 .B -h, --help                   Print this Help.
 .TP
-.B -i, --import                 [FILE.tar - optional] Input file to Import jellyfin-backup.tar.
+.B -i, --import                 Display list of backup .tar files to Import and automatically restores the selected backup.
 .BR
     ├── Media metadata will only import if your new OS/setup and old OS/setup media folders are exactly the same.
 .BR
@@ -57,6 +57,10 @@ is a set of scripts to install/manage and update the jellyfin-combined tar.gz ge
 .B -S, --stop                   Stop Jellyfin.
 .TP
 .B -t, --status                 Status of Jellyfin.
+.TP
+-B -sm,  --search-media         Search Media in your media directory/directories.
+.TP
+.B -lm,  --list-media           Provide a tree list of all media (output saved to /tmp/media.txt).
 .TP
 .B -u, --update-jellyfin        [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
 .BR

--- a/scripts/jellyman
+++ b/scripts/jellyman
@@ -1,5 +1,5 @@
 #!/bin/bash
-jellymanVersion="v1.9.3"
+jellymanVersion="v1.9.4"
 logDir=/opt/jellyfin/log
 logFile=$logDir/jellyman.log
 sourceFile="/opt/jellyfin/config/jellyman.conf"
@@ -16,12 +16,14 @@ helpList="
 -d,   --disable              Disable Jellyfin on System Start.
 -e,   --enable               Enable Jellyfin on System Start.
 -h,   --help                 Print this Help.
--i,   --import               [FILE.tar - optional] Input file to Import jellyfin-backup.tar.
+-i,   --import               Display list of backup .tar files to Import and automatically restores the selected backup.
 -p,   --permissions          [DIRECTORY - optional] Reset the permissions of Jellyfin's Media Library or supplied directory.
 -r,   --restart              Restart Jellyfin.
 -s,   --start                Start Jellyfin.
 -S,   --stop                 Stop Jellyfin.
 -t,   --status               Status of Jellyfin.
+-sm,  --search-media         Search Media in your media directory/directories.
+-lm,  --list-media           Provide a tree list of all media (output saved to /tmp/media.txt).
 -u,   --update-jellyfin      [URL - optional] Downloads and updates the current stable or supplied Jellyfin version.
 -U,   --update-jellyman      Update Jellyman - The Jellyfin Manager.
 -ub,  --update-beta          Update Jellyfin to the most recent Beta.
@@ -35,7 +37,7 @@ helpList="
 -rn,  --rename               Batch renaming script for TV shows.
 -cp,  --change-http          Change Jellyfins http network port - Default = 8096.
 -cps, --change-https         Change Jellyfins https network port - Default = 8920.
--ik,  --import-key           Import an API key.
+-ik,  --import-key           Import a Jellyfin API key (Needed for `-ls` command).
 -md,  --media-directory      Change the Media Directory for Jellyman.
 -tc,  --transcode            Transcode a file/directory with a GB per hour filter (1.5GB is recommended).
 -tcp, --transcode-progress   View progress of the Transcode.
@@ -573,6 +575,24 @@ CheckApiKey()
 	else
 		return 0
 	fi
+}
+
+SearchMedia()
+{
+	HasSudo
+	source $sourceFile
+	query=$1
+	tree -h -i -f --du -I "*.nfo" $defaultPath | grep -i "$query"
+)
+}
+
+ListMedia()
+{
+	HasSudo
+	source $sourceFile
+	echo ">>> List of media stored in /tmp/media.txt"
+	tree -h --du -I "*.nfo" $defaultPath > /tmp/media.txt
+	less -P 'File %f Position %lb (%l lines) %P\% | Press "Q" to exit' /tmp/media.txt
 }
 
 HttpPortChange()
@@ -1505,6 +1525,8 @@ ChangeMediaDirectory()
 		echo "| Please enter all media directories separated by a space |"
 		echo "|                       example:                          |"
 		echo "|          /media/hdd1/Movies /media/hdd2/TV              |"
+		echo "|                       example2:                         |"
+		echo "|               /media/hdd1 /media/hdd2                   |"
 		echo "|---------------------------------------------------------|"
 		echo
 		echo $warning
@@ -1583,6 +1605,9 @@ if [ -n "$1" ]; then
 			-s | --start) Control "start" ;;
 			-S | --stop) Control "stop" ;;
 			-t | --status) Status ;;
+			-sm | --search-media) SearchMedia $2
+									shift ;;
+			-lm | --list-media) ListMedia ;;
 			-u | --update-jellyfin) if [[ "$2" == "-"* ]]; then
 					 Update
 				 else
@@ -1608,10 +1633,6 @@ if [ -n "$1" ]; then
 			-md | --media-directory) ChangeMediaDirectory ;;
 			-tc | --transcode) Transcode ;;
 			-tcp | --transcode-progress) ViewTranscodeProgress ;;
-#			-tcf) TranscodeFile $2 $3 $4
-#						shift
-#						shift
-#						shift ;;
 			-tcs | --transcode-stop) TranscodeStop ;;
 			-X | --uninstall) Uninstall ;;
 			--CallFunc) CallFunc "$2"

--- a/scripts/jellyman-functions
+++ b/scripts/jellyman-functions
@@ -322,7 +322,7 @@ Log()
 
 	_logFileLines=$(wc -l $_logFile | cut -d " " -f 1)
 
-	if [ $_logFileLines -ge 1000 ]; then
+	if [ $_logFileLines -ge 5000 ]; then
 		sed -i '1d' $_logFile
 	fi
 }
@@ -355,7 +355,7 @@ ViewLog()
 	logDir=$1
 	PresentList "$logDir" "> Please enter the number corresponding with the log you wish to view." ".log"
 	logToView=$presentListResult
-	less +G -FS $logDir/$logToView
+	less -P 'File %f Position %lb (%l lines) %P\% | Press "Q" to exit' +G -FS $logDir/$logToView
 
 # ViewLog "/dir/to/logs"
 }


### PR DESCRIPTION
## Changes
- jellyman.log now keeps 5000 lines instead of 1000.
- Updated the `--help` command.
- Changed some laguage outputs.
- Added help info for `less` command (`jellyman -vl`)

## Additions 
- `-sm,  --search-media         Search Media in your media directory/directories.`
- `-lm,  --list-media           Provide a tree list of all media (output saved to /tmp/media.txt).`